### PR TITLE
Change reserved keywords to be namespace-prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,43 +50,43 @@ Oksa requires Clojure 1.10+.
 Fields can be selected:
 
 ```clojure
-(core/unparse [:foo])
+(oksa/unparse [:foo])
 ;; => "{foo}"
 
-(core/unparse [:foo :bar])
+(oksa/unparse [:foo :bar])
 ;; => "{foo bar}"
 
-(core/unparse [:bar [:qux [:baz]]])
+(oksa/unparse [:bar [:qux [:baz]]])
 ;; => "{bar{qux{baz}}}"
 
-(core/unparse [:foo :bar [:qux [:baz]]])
+(oksa/unparse [:foo :bar [:qux [:baz]]])
 ;; => "{foo bar{qux{baz}}}"
 
-(core/unparse [:foo :bar [:qux :baz]])
+(oksa/unparse [:foo :bar [:qux :baz]])
 ;; => "{foo bar{qux baz}}"
 
-(core/unparse [:foo [:bar [:baz :qux] :frob]])
+(oksa/unparse [:foo [:bar [:baz :qux] :frob]])
 ;; => "{foo{bar{baz qux} frob}}"
 ```
 
 Strings are supported for field names:
 
 ```clojure
-(core/unparse ["query" "foo"])
+(oksa/unparse ["query" "foo"])
 ;; => "{query foo}"
 ```
 
 Aliases:
 
 ```clojure
-(core/unparse [[:foo {:alias :bar}]])
+(oksa/unparse [[:foo {:alias :bar}]])
 ;; => "{bar:foo}"
 ```
 
 Arguments:
 
 ```clojure
-(core/unparse [[:foo {:arguments {:a 1
+(oksa/unparse [[:foo {:arguments {:a 1
                                   :b "hello world"
                                   :c true
                                   :d nil
@@ -101,11 +101,11 @@ Arguments:
 Directives:
 
 ```clojure
-(core/unparse [[:foo {:directives [:bar]}]])
+(oksa/unparse [[:foo {:directives [:bar]}]])
 ;; => "{foo@bar}"
 
 ;; with arguments
-(core/unparse [[:foo {:directives [[:bar {:arguments {:qux 123}}]]}]])
+(oksa/unparse [[:foo {:directives [[:bar {:arguments {:qux 123}}]]}]])
 ;; => "{foo@bar(qux:123)}"
 ```
 
@@ -114,25 +114,25 @@ Directives:
 Queries can be created:
 
 ```clojure
-(core/unparse [:query [:foo :bar [:qux [:baz]]]])
+(oksa/unparse [:oksa/query [:foo :bar [:qux [:baz]]]])
 ;; => "query {foo bar{qux{baz}}}"
 
-(core/unparse [:query {:name :Foo} [:foo]])
+(oksa/unparse [:oksa/query {:name :Foo} [:foo]])
 ;; => "query Foo {foo}"
 ```
 
 Queries can have directives:
 
 ```clojure
-(core/unparse [:query {:directives [:foo]} [:foo]])
+(oksa/unparse [:oksa/query {:directives [:foo]} [:foo]])
 ;; => "query @foo{foo}"
 
-(core/unparse [:query {:directives [:foo :bar]} [:foo]])
+(oksa/unparse [:oksa/query {:directives [:foo :bar]} [:foo]])
 ;; => "query @foo @bar{foo}"
 
 ;; with arguments
 
-(core/unparse [:query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])
+(oksa/unparse [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])
 ;; => "query @foo(bar:123){foo}"
 ```
 
@@ -141,10 +141,10 @@ Queries can have directives:
 Mutations can be created:
 
 ```clojure
-(core/unparse [:mutation [:foo :bar [:qux [:baz]]]])
+(oksa/unparse [:oksa/mutation [:foo :bar [:qux [:baz]]]])
 ;; => "mutation {foo bar{qux{baz}}}"
 
-(core/unparse [:mutation {:name :Foo} [:foo]])
+(oksa/unparse [:oksa/mutation {:name :Foo} [:foo]])
 ;; => "mutation Foo {foo}"
 ```
 
@@ -153,10 +153,10 @@ Mutations can be created:
 Subscriptions can be created:
 
 ```clojure
-(core/unparse [:subscription [:foo :bar [:qux [:baz]]]])
+(oksa/unparse [:oksa/subscription [:foo :bar [:qux [:baz]]]])
 ;; => "subscription {foo bar{qux{baz}}}"
 
-(core/unparse [:subscription {:name :Foo} [:foo]])
+(oksa/unparse [:oksa/subscription {:name :Foo} [:foo]])
 ;; => "subscription Foo {foo}"
 ```
 
@@ -165,13 +165,13 @@ Subscriptions can be created:
 Named types are supported:
 
 ```clojure
-(core/unparse [:query {:variables [:fooVar :FooType]}
+(oksa/unparse [:oksa/query {:variables [:fooVar :FooType]}
                [:fooField]])
 ;; => "query ($fooVar:FooType){fooField}"
 
-(core/unparse [:query {:variables
-                       [:fooVar :FooType
-                        :barVar :BarType]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar :FooType
+                             :barVar :BarType]}
                [:fooField]])
 ;; => "query ($fooVar:FooType,$barVar:BarType){fooField}"
 ```
@@ -179,26 +179,26 @@ Named types are supported:
 Lists can be created:
 
 ```clojure
-(core/unparse [:query {:variables
-                       [:fooVar [:oksa/list :FooType]]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar [:oksa/list :FooType]]}
                [:fooField]])
 
 ;; or
 
-(core/unparse [:query {:variables
-                       [:fooVar [:FooType]]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar [:FooType]]}
                [:fooField]])
 ;; => "query ($fooVar:[FooType]){fooField}"
 
-(core/unparse [:query {:variables
-                       [:fooVar [:oksa/list
-                                 [:oksa/list
-                                  :BarType]]]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar [:oksa/list
+                                      [:oksa/list
+                                       :BarType]]]}
                [:fooField]])
 
 ;; or
 
-(core/unparse [:query {:variables [:fooVar [[:BarType]]]}
+(oksa/unparse [:oksa/query {:variables [:fooVar [[:BarType]]]}
                [:fooField]])
 ;; => "query ($fooVar:[[BarType]]){fooField}"
 ```
@@ -206,24 +206,24 @@ Lists can be created:
 Non-null types can be created:
 
 ```clojure
-(core/unparse [:query {:variables
-                       [:fooVar [:FooType {:oksa/non-null? true}]]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar [:FooType {:oksa/non-null? true}]]}
                [:fooField]])
 
 ;; or
 
-(core/unparse [:query {:variables [:fooVar :FooType!]}
+(oksa/unparse [:oksa/query {:variables [:fooVar :FooType!]}
                [:fooField]])
 ;; => "query ($fooVar:FooType!){fooField}"
 
-(core/unparse [:query {:variables
-                       [:fooVar [:oksa/list {:oksa/non-null? true}
-                                 :BarType]]}
+(oksa/unparse [:oksa/query {:variables
+                            [:fooVar [:oksa/list {:oksa/non-null? true}
+                                      :BarType]]}
                [:fooField]])
 
 ;; or
 
-(core/unparse [:query {:variables [:fooVar [:! :BarType]]}
+(oksa/unparse [:oksa/query {:variables [:fooVar [:! :BarType]]}
                [:fooField]])
 ;; => "query ($fooVar:[BarType]!){fooField}"
 ```
@@ -231,7 +231,7 @@ Non-null types can be created:
 Getting crazy with it:
 
 ```clojure
-(core/unparse [:query {:variables [:fooVar [:! [:! :BarType!]]]}
+(oksa/unparse [:oksa/query {:variables [:fooVar [:! [:! :BarType!]]]}
                [:fooField]])
 ;; => "query ($fooVar:[[BarType!]!]!){fooField}"
 ```
@@ -239,11 +239,11 @@ Getting crazy with it:
 Variable definitions can have directives:
 
 ```clojure
-(core/unparse [:query {:variables [:foo {:directives [:fooDirective]} :Bar]}
+(oksa/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]}
                [:fooField]])
 ;; => "query ($foo:Bar @fooDirective){fooField}"
 
-(core/unparse [:query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
+(oksa/unparse [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
                [:fooField]])
 ;; => "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
 ```
@@ -253,23 +253,23 @@ Variable definitions can have directives:
 Fragment definitions can be created:
 
 ```clojure
-(core/unparse [:fragment {:name :Foo :on :Bar} [:foo]])
+(oksa/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo]])
 ;; => "fragment Foo on Bar{foo}"
 
-(core/unparse [:# {:name :Foo :on :Bar} [:foo]]) ; shortcut
+(oksa/unparse [:# {:name :Foo :on :Bar} [:foo]]) ; shortcut
 ;; => "fragment Foo on Bar{foo}"
 
 ;; with directives
-(core/unparse [:fragment {:name :foo
-                          :on :Foo
-                          :directives [:fooDirective]}
+(oksa/unparse [:oksa/fragment {:name :foo
+                               :on :Foo
+                               :directives [:fooDirective]}
                [:bar]])
 ;; => "fragment foo on Foo@fooDirective{bar}"
 
 ;; with arguments
-(core/unparse [:fragment {:name :foo
-                          :on :Foo
-                          :directives [[:fooDirective {:arguments {:bar 123}}]]}
+(oksa/unparse [:oksa/fragment {:name :foo
+                               :on :Foo
+                               :directives [[:fooDirective {:arguments {:bar 123}}]]}
                [:bar]])
 ;; => "fragment foo on Foo@fooDirective(bar:123){bar}"
 ```
@@ -277,19 +277,19 @@ Fragment definitions can be created:
 Fragment spreads:
 
 ```clojure
-(core/unparse [:foo [:fragment-spread {:name :bar}]])
+(oksa/unparse [:foo [:oksa/fragment-spread {:name :bar}]])
 
 ;; or
 
-(core/unparse [:foo [:... {:name :bar}]])
+(oksa/unparse [:foo [:... {:name :bar}]])
 ;; => "{foo ...bar}"
 
 ;; with directives
-(core/unparse [[:... {:name :foo :directives [:bar]}]])
+(oksa/unparse [[:... {:name :foo :directives [:bar]}]])
 ;; => "{...foo@bar}"
 
 ;; with arguments
-(core/unparse [[:... {:name :foo
+(oksa/unparse [[:... {:name :foo
                       :directives [[:bar {:arguments {:qux 123}}]]}]])
 ;; => "{...foo@bar(qux:123)}"
 ```
@@ -297,22 +297,22 @@ Fragment spreads:
 Inline fragments:
 
 ```clojure
-(core/unparse [:foo [:inline-fragment [:bar]]])
+(oksa/unparse [:foo [:oksa/inline-fragment [:bar]]])
 
 ;; or
 
-(core/unparse [:foo [:... [:bar]]])
+(oksa/unparse [:foo [:... [:bar]]])
 ;; => "{foo ...{bar}}"
 
-(core/unparse [:foo [:... {:on :Bar} [:bar]]])
+(oksa/unparse [:foo [:... {:on :Bar} [:bar]]])
 ;; => "{foo ...on Bar{bar}}"
 
 ;; with directives
-(core/unparse [[:... {:directives [:foo]} [:bar]]])
+(oksa/unparse [[:... {:directives [:foo]} [:bar]]])
 ;; => "{...@foo{bar}}"
 
 ;; with arguments
-(core/unparse [[:... {:directives [[:foo {:arguments {:bar 123}}]]}
+(oksa/unparse [[:... {:directives [[:foo {:arguments {:bar 123}}]]}
                 [:foobar]]])
 ;; => "{...@foo(bar:123){foobar}}"
 ```
@@ -322,15 +322,15 @@ Inline fragments:
 Putting it all together:
 
 ```clojure
-(core/unparse [:document
+(oksa/unparse [:oksa/document
                [:foo]
-               [:query [:bar]]
-               [:mutation [:qux]]
-               [:subscription [:baz]]
-               [:fragment {:name :foo :on :Foo} [:bar]]])
+               [:oksa/query [:bar]]
+               [:oksa/mutation [:qux]]
+               [:oksa/subscription [:baz]]
+               [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
 ;; => "{foo}\nquery {bar}\nmutation {qux}\nsubscription {baz}\nfragment foo on Foo{bar}"
 
-(core/unparse [:<> [:foo] [:bar]]) ; :<> also supported
+(oksa/unparse [:<> [:foo] [:bar]]) ; :<> also supported
 ;; => "{foo}\n{bar}"
 ```
 

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -89,6 +89,9 @@
 (def ^:private re-variable-reference (re-pattern (str "[$]" name-pattern)))
 (def ^:private re-enum-value (re-pattern (str "(?!(true|false|null))" name-pattern)))
 
+(def ^:private reserved-keywords
+  (set (filter #(some-> % namespace (= "oksa")) (keys transform-map))))
+
 (def ^:private graphql-dsl-lang
   [:schema {:registry {::Document [:or
                                    [:schema [:ref ::Definition]]
@@ -172,7 +175,7 @@
                        ::NakedField [:schema [:ref ::FieldName]]
                        ::FieldName [:and
                                     [:schema [:ref ::Name]]
-                                    [:not [:enum :oksa/document]]]
+                                    [:fn #(not (reserved-keywords %))]]
                        ::FragmentSpread [:cat
                                          [:enum :oksa/fragment-spread :...]
                                          [:? [:map

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -41,13 +41,13 @@
                                            ::InlineFragment (util/transform-malli-ast transform-map value))])
                             (some? children) (into [(util/transform-malli-ast transform-map children)]))))
                       xs)))]
-    {:document document
+    {:oksa/document document
      :<> document
-     :fragment fragment
+     :oksa/fragment fragment
      :# fragment
-     :query (partial operation :query)
-     :mutation (partial operation :mutation)
-     :subscription (partial operation :subscription)
+     :oksa/query (partial operation :query)
+     :oksa/mutation (partial operation :mutation)
+     :oksa/subscription (partial operation :subscription)
      :select (fn [opts xs] (into [:selectionset opts] xs))
      :... (fn fragment-dispatcher
             ([opts]
@@ -56,8 +56,8 @@
              (if (some? (:name opts))
                (fragment-spread opts xs)
                (inline-fragment opts xs))))
-     :fragment-spread fragment-spread
-     :inline-fragment inline-fragment
+     :oksa/fragment-spread fragment-spread
+     :oksa/inline-fragment inline-fragment
      ::SelectionSet selection-set
      ::Field (fn [[name opts & xs]]
                (into [:selection {} [:field (merge (update opts
@@ -93,7 +93,7 @@
   [:schema {:registry {::Document [:or
                                    [:schema [:ref ::Definition]]
                                    [:cat
-                                    [:enum :document :<>]
+                                    [:enum :oksa/document :<>]
                                     [:? :map]
                                     [:+ [:schema [:ref ::Definition]]]]]
                        ::Definition [:schema [:ref ::ExecutableDefinition]]
@@ -101,7 +101,7 @@
                                                [:schema [:ref ::OperationDefinition]]
                                                [:schema [:ref ::FragmentDefinition]]]
                        ::FragmentDefinition [:cat
-                                             [:enum :fragment :#]
+                                             [:enum :oksa/fragment :#]
                                              [:? [:map
                                                   [:name {:optional false}
                                                    [:ref ::FragmentName]]
@@ -111,7 +111,7 @@
                                              [:+ [:schema [:ref ::SelectionSet]]]]
                        ::OperationDefinition [:or
                                               [:cat
-                                               [:enum :query :mutation :subscription]
+                                               [:enum :oksa/query :oksa/mutation :oksa/subscription]
                                                [:? [:map
                                                     [:name {:optional true} [:ref ::Name]]
                                                     [:variables {:optional true}
@@ -172,16 +172,16 @@
                        ::NakedField [:schema [:ref ::FieldName]]
                        ::FieldName [:and
                                     [:schema [:ref ::Name]]
-                                    [:not (into [:enum] (keys transform-map))]]
+                                    [:not [:enum :oksa/document]]]
                        ::FragmentSpread [:cat
-                                         [:enum :fragment-spread :...]
+                                         [:enum :oksa/fragment-spread :...]
                                          [:? [:map
                                               [:name {:optional false}
                                                [:ref ::FragmentName]]
                                               [:directives {:optional true}
                                                [:ref ::Directives]]]]]
                        ::InlineFragment [:cat
-                                         [:enum :inline-fragment :...]
+                                         [:enum :oksa/inline-fragment :...]
                                          [:? [:map
                                               [:directives {:optional true}
                                                [:ref ::Directives]]

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -9,19 +9,31 @@
     (t/is (= "query {foo bar}" (core/unparse [:oksa/query {} [:foo :bar]])))
     (t/is (= "query {bar{qux{baz}}}" (core/unparse [:oksa/query {} [:bar [:qux [:baz]]]])))
     (t/is (= "query {foo bar{qux{baz}}}" (core/unparse [:oksa/query {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "query Foo {foo}" (core/unparse [:oksa/query {:name :Foo} [:foo]]))))
+    (t/is (= "query Foo {foo}" (core/unparse [:oksa/query {:name :Foo} [:foo]])))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? Exception (core/unparse [:oksa/query [:oksa/query [:baz]]])))
+      (t/is (= "query {query{baz}}" (core/unparse [:oksa/query [:query [:baz]]])))
+      (t/is (= "{query{query{baz}}}" (core/unparse [:query [:query [:baz]]])))))
   (t/testing "mutation"
     (t/is (= "mutation {foo}" (core/unparse [:oksa/mutation {} [:foo]])))
     (t/is (= "mutation {foo bar}" (core/unparse [:oksa/mutation {} [:foo :bar]])))
     (t/is (= "mutation {bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:bar [:qux [:baz]]]])))
     (t/is (= "mutation {foo bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "mutation Foo {foo}" (core/unparse [:oksa/mutation {:name :Foo} [:foo]]))))
+    (t/is (= "mutation Foo {foo}" (core/unparse [:oksa/mutation {:name :Foo} [:foo]])))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? Exception (core/unparse [:oksa/mutation [:oksa/mutation [:baz]]])))
+      (t/is (= "mutation {mutation{baz}}" (core/unparse [:oksa/mutation [:mutation [:baz]]])))
+      (t/is (= "{mutation{mutation{baz}}}" (core/unparse [:mutation [:mutation [:baz]]])))))
   (t/testing "subscription"
     (t/is (= "subscription {foo}" (core/unparse [:oksa/subscription {} [:foo]])))
     (t/is (= "subscription {foo bar}" (core/unparse [:oksa/subscription {} [:foo :bar]])))
     (t/is (= "subscription {bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:bar [:qux [:baz]]]])))
     (t/is (= "subscription {foo bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "subscription Foo {foo}" (core/unparse [:oksa/subscription {:name :Foo} [:foo]]))))
+    (t/is (= "subscription Foo {foo}" (core/unparse [:oksa/subscription {:name :Foo} [:foo]])))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? Exception (core/unparse [:oksa/subscription [:oksa/subscription [:baz]]])))
+      (t/is (= "subscription {subscription{baz}}" (core/unparse [:oksa/subscription [:subscription [:baz]]])))
+      (t/is (= "{subscription{subscription{baz}}}" (core/unparse [:subscription [:subscription [:baz]]])))))
   (t/testing "selection set"
     (t/is (= "{foo}"
            (core/unparse [:foo])))
@@ -80,7 +92,11 @@
                             [:oksa/query [:bar]]
                             [:oksa/mutation [:qux]]
                             [:oksa/subscription [:baz]]
-                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]]))))
+                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]])))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? Exception (core/unparse [:oksa/document [:oksa/document [:baz]]])))
+      (t/is (= "{document{baz}}" (core/unparse [:oksa/document [:document [:baz]]])))
+      (t/is (= "{document{document{baz}}}" (core/unparse [:document [:document [:baz]]])))))
   (t/testing "fragment"
     (t/is (= "fragment Foo on Bar{foo}"
              (core/unparse [:# {:name :Foo :on :Bar} [:foo]])
@@ -93,7 +109,11 @@
              (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])))
     (t/is (= "fragment Foo on Bar{foo bar{qux{baz}}}"
              (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
-             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]]))))
+             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? Exception (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:oksa/fragment {:name :Foo :on :Bar} [:baz]]])))
+      (t/is (= "fragment Foo on Bar{fragment{baz}}" (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:fragment [:baz]]])))
+      (t/is (= "{fragment{fragment{baz}}}" (core/unparse [:fragment [:fragment [:baz]]])))))
   (t/testing "fragment spread"
     (t/is (= "{foo ...bar}"
              (core/unparse [:foo [:... {:name :bar}]])

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -11,7 +11,7 @@
     (t/is (= "query {foo bar{qux{baz}}}" (core/unparse [:oksa/query {} [:foo :bar [:qux [:baz]]]])))
     (t/is (= "query Foo {foo}" (core/unparse [:oksa/query {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? Exception (core/unparse [:oksa/query [:oksa/query [:baz]]])))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/query [:oksa/query [:baz]]])))
       (t/is (= "query {query{baz}}" (core/unparse [:oksa/query [:query [:baz]]])))
       (t/is (= "{query{query{baz}}}" (core/unparse [:query [:query [:baz]]])))))
   (t/testing "mutation"
@@ -21,7 +21,7 @@
     (t/is (= "mutation {foo bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:foo :bar [:qux [:baz]]]])))
     (t/is (= "mutation Foo {foo}" (core/unparse [:oksa/mutation {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? Exception (core/unparse [:oksa/mutation [:oksa/mutation [:baz]]])))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/mutation [:oksa/mutation [:baz]]])))
       (t/is (= "mutation {mutation{baz}}" (core/unparse [:oksa/mutation [:mutation [:baz]]])))
       (t/is (= "{mutation{mutation{baz}}}" (core/unparse [:mutation [:mutation [:baz]]])))))
   (t/testing "subscription"
@@ -31,7 +31,7 @@
     (t/is (= "subscription {foo bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:foo :bar [:qux [:baz]]]])))
     (t/is (= "subscription Foo {foo}" (core/unparse [:oksa/subscription {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? Exception (core/unparse [:oksa/subscription [:oksa/subscription [:baz]]])))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/subscription [:oksa/subscription [:baz]]])))
       (t/is (= "subscription {subscription{baz}}" (core/unparse [:oksa/subscription [:subscription [:baz]]])))
       (t/is (= "{subscription{subscription{baz}}}" (core/unparse [:subscription [:subscription [:baz]]])))))
   (t/testing "selection set"
@@ -94,7 +94,7 @@
                             [:oksa/subscription [:baz]]
                             [:oksa/fragment {:name :foo :on :Foo} [:bar]]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? Exception (core/unparse [:oksa/document [:oksa/document [:baz]]])))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/document [:oksa/document [:baz]]])))
       (t/is (= "{document{baz}}" (core/unparse [:oksa/document [:document [:baz]]])))
       (t/is (= "{document{document{baz}}}" (core/unparse [:document [:document [:baz]]])))))
   (t/testing "fragment"
@@ -111,7 +111,7 @@
              (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
              (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? Exception (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:oksa/fragment {:name :Foo :on :Bar} [:baz]]])))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:oksa/fragment {:name :Foo :on :Bar} [:baz]]])))
       (t/is (= "fragment Foo on Bar{fragment{baz}}" (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:fragment [:baz]]])))
       (t/is (= "{fragment{fragment{baz}}}" (core/unparse [:fragment [:fragment [:baz]]])))))
   (t/testing "fragment spread"

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -5,23 +5,23 @@
 
 (t/deftest unparse-test
   (t/testing "query"
-    (t/is (= "query {foo}" (core/unparse [:query {} [:foo]])))
-    (t/is (= "query {foo bar}" (core/unparse [:query {} [:foo :bar]])))
-    (t/is (= "query {bar{qux{baz}}}" (core/unparse [:query {} [:bar [:qux [:baz]]]])))
-    (t/is (= "query {foo bar{qux{baz}}}" (core/unparse [:query {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "query Foo {foo}" (core/unparse [:query {:name :Foo} [:foo]]))))
+    (t/is (= "query {foo}" (core/unparse [:oksa/query {} [:foo]])))
+    (t/is (= "query {foo bar}" (core/unparse [:oksa/query {} [:foo :bar]])))
+    (t/is (= "query {bar{qux{baz}}}" (core/unparse [:oksa/query {} [:bar [:qux [:baz]]]])))
+    (t/is (= "query {foo bar{qux{baz}}}" (core/unparse [:oksa/query {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "query Foo {foo}" (core/unparse [:oksa/query {:name :Foo} [:foo]]))))
   (t/testing "mutation"
-    (t/is (= "mutation {foo}" (core/unparse [:mutation {} [:foo]])))
-    (t/is (= "mutation {foo bar}" (core/unparse [:mutation {} [:foo :bar]])))
-    (t/is (= "mutation {bar{qux{baz}}}" (core/unparse [:mutation {} [:bar [:qux [:baz]]]])))
-    (t/is (= "mutation {foo bar{qux{baz}}}" (core/unparse [:mutation {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "mutation Foo {foo}" (core/unparse [:mutation {:name :Foo} [:foo]]))))
+    (t/is (= "mutation {foo}" (core/unparse [:oksa/mutation {} [:foo]])))
+    (t/is (= "mutation {foo bar}" (core/unparse [:oksa/mutation {} [:foo :bar]])))
+    (t/is (= "mutation {bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:bar [:qux [:baz]]]])))
+    (t/is (= "mutation {foo bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "mutation Foo {foo}" (core/unparse [:oksa/mutation {:name :Foo} [:foo]]))))
   (t/testing "subscription"
-    (t/is (= "subscription {foo}" (core/unparse [:subscription {} [:foo]])))
-    (t/is (= "subscription {foo bar}" (core/unparse [:subscription {} [:foo :bar]])))
-    (t/is (= "subscription {bar{qux{baz}}}" (core/unparse [:subscription {} [:bar [:qux [:baz]]]])))
-    (t/is (= "subscription {foo bar{qux{baz}}}" (core/unparse [:subscription {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "subscription Foo {foo}" (core/unparse [:subscription {:name :Foo} [:foo]]))))
+    (t/is (= "subscription {foo}" (core/unparse [:oksa/subscription {} [:foo]])))
+    (t/is (= "subscription {foo bar}" (core/unparse [:oksa/subscription {} [:foo :bar]])))
+    (t/is (= "subscription {bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:bar [:qux [:baz]]]])))
+    (t/is (= "subscription {foo bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "subscription Foo {foo}" (core/unparse [:oksa/subscription {:name :Foo} [:foo]]))))
   (t/testing "selection set"
     (t/is (= "{foo}"
            (core/unparse [:foo])))
@@ -63,114 +63,114 @@
                (core/unparse [[:fooField {:arguments {:foo (str "foo\b\f\r\n\tbar")}}]]))))))
   (t/testing "document"
     (t/is (= "{foo}"
-           (core/unparse [:<> [:foo]])
-           (core/unparse [:document [:foo]])))
+             (core/unparse [:<> [:foo]])
+             (core/unparse [:oksa/document [:foo]])))
     (t/is (= "{foo}\n{bar}"
-           (core/unparse [:<> [:foo] [:bar]])
-           (core/unparse [:document [:foo] [:bar]])))
+             (core/unparse [:<> [:foo] [:bar]])
+             (core/unparse [:oksa/document [:foo] [:bar]])))
     (t/is (= "{foo}\nquery {bar}\nmutation {qux}\nsubscription {baz}\nfragment foo on Foo{bar}"
-           (core/unparse [:<>
-                          [:foo]
-                          [:query [:bar]]
-                          [:mutation [:qux]]
-                          [:subscription [:baz]]
-                          [:fragment {:name :foo :on :Foo} [:bar]]])
-           (core/unparse [:document
-                          [:foo]
-                          [:query [:bar]]
-                          [:mutation [:qux]]
-                          [:subscription [:baz]]
-                          [:fragment {:name :foo :on :Foo} [:bar]]]))))
+             (core/unparse [:<>
+                            [:foo]
+                            [:oksa/query [:bar]]
+                            [:oksa/mutation [:qux]]
+                            [:oksa/subscription [:baz]]
+                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
+             (core/unparse [:oksa/document
+                            [:foo]
+                            [:oksa/query [:bar]]
+                            [:oksa/mutation [:qux]]
+                            [:oksa/subscription [:baz]]
+                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]]))))
   (t/testing "fragment"
     (t/is (= "fragment Foo on Bar{foo}"
-           (core/unparse [:# {:name :Foo :on :Bar} [:foo]])
-           (core/unparse [:fragment {:name :Foo :on :Bar} [:foo]])))
+             (core/unparse [:# {:name :Foo :on :Bar} [:foo]])
+             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo]])))
     (t/is (= "fragment Foo on Bar{foo bar}"
-           (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar]])
-           (core/unparse [:fragment {:name :Foo :on :Bar} [:foo :bar]])))
+             (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar]])
+             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar]])))
     (t/is (= "fragment Foo on Bar{bar{qux{baz}}}"
-           (core/unparse [:# {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])
-           (core/unparse [:fragment {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])))
+             (core/unparse [:# {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])
+             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])))
     (t/is (= "fragment Foo on Bar{foo bar{qux{baz}}}"
-           (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
-           (core/unparse [:fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]]))))
+             (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
+             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]]))))
   (t/testing "fragment spread"
     (t/is (= "{foo ...bar}"
-           (core/unparse [:foo [:... {:name :bar}]])
-           (core/unparse [:foo [:fragment-spread {:name :bar}]]))))
+             (core/unparse [:foo [:... {:name :bar}]])
+             (core/unparse [:foo [:oksa/fragment-spread {:name :bar}]]))))
   (t/testing "inline fragment"
     (t/is (= "{foo ...{bar}}"
-           (core/unparse [:foo [:... [:bar]]])
-           (core/unparse [:foo [:inline-fragment [:bar]]])))
+             (core/unparse [:foo [:... [:bar]]])
+             (core/unparse [:foo [:oksa/inline-fragment [:bar]]])))
     (t/is (= "{foo ...on Bar{bar}}"
-           (core/unparse [:foo [:... {:on :Bar} [:bar]]])
-           (core/unparse [:foo [:inline-fragment {:on :Bar} [:bar]]]))))
+             (core/unparse [:foo [:... {:on :Bar} [:bar]]])
+             (core/unparse [:foo [:oksa/inline-fragment {:on :Bar} [:bar]]]))))
   (t/testing "variable definitions"
     (t/testing "named type"
       (t/is (= "query ($fooVar:FooType){fooField}"
-             (core/unparse [:query {:variables [:fooVar :FooType]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar :FooType]}
+                              [:fooField]]))))
     (t/testing "non-null named type")
     (t/is (= "query ($fooVar:FooType!){fooField}"
-           (core/unparse [:query {:variables [:fooVar [:FooType {:non-null true}]]}
-                          [:fooField]])))
+             (core/unparse [:oksa/query {:variables [:fooVar [:FooType {:non-null true}]]}
+                            [:fooField]])))
     (t/testing "named type within list"
       (t/is (= "query ($fooVar:[FooType]){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list :FooType]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [:FooType]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list :FooType]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [:FooType]]}
+                              [:fooField]]))))
     (t/testing "non-null named type within list"
       (t/is (= "query ($fooVar:[FooType!]){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list
-                                                         [:FooType {:non-null true}]]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [:FooType!]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list
+                                                                [:FooType {:non-null true}]]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [:FooType!]]}
+                              [:fooField]]))))
     (t/testing "named type within list"
       (t/is (= "query ($fooVar:[BarType]!){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                         :BarType]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [:! :BarType]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                :BarType]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [:! :BarType]]}
+                              [:fooField]]))))
     (t/testing "non-null type within non-null list"
       (t/is (= "query ($fooVar:[BarType!]!){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                         [:BarType {:non-null true}]]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [:! :BarType!]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                [:BarType {:non-null true}]]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [:! :BarType!]]}
+                              [:fooField]]))))
     (t/testing "named type within list within list"
       (t/is (= "query ($fooVar:[[BarType]]){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list
-                                                         [:oksa/list
-                                                          :BarType]]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [[:BarType]]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list
+                                                                [:oksa/list
+                                                                 :BarType]]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [[:BarType]]]}
+                              [:fooField]]))))
     (t/testing "non-null list within non-null list"
       (t/is (= "query ($fooVar:[[BarType]!]!){fooField}"
-             (core/unparse [:query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                         [:oksa/list {:non-null true}
-                                                          :BarType]]]}
-                            [:fooField]])
-             (core/unparse [:query {:variables [:fooVar [:! [:! :BarType]]]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                [:oksa/list {:non-null true}
+                                                                 :BarType]]]}
+                              [:fooField]])
+               (core/unparse [:oksa/query {:variables [:fooVar [:! [:! :BarType]]]}
+                              [:fooField]]))))
     (t/testing "multiple variable definitions"
       (t/is (= "query ($fooVar:FooType,$barVar:BarType){fooField}"
-             (core/unparse [:query {:variables [:fooVar :FooType
-                                                :barVar :BarType]}
-                            [:fooField]]))))
+               (core/unparse [:oksa/query {:variables [:fooVar :FooType
+                                                       :barVar :BarType]}
+                              [:fooField]]))))
     (t/testing "default values"
       (t/is (= "query ($fooVar:Foo=123){fooField(foo:$fooVar)}"
-             (core/unparse [:query {:variables [:$fooVar {:default 123} :Foo]}
-                            [[:fooField {:arguments {:foo :$fooVar}}]]])))))
+               (core/unparse [:oksa/query {:variables [:$fooVar {:default 123} :Foo]}
+                              [[:fooField {:arguments {:foo :$fooVar}}]]])))))
   (t/testing "variable names"
     (doseq [variable-name [:fooVar :$fooVar "fooVar" "$fooVar"]]
       (t/is (= "query ($fooVar:FooType){fooField}"
-             (core/unparse [:query {:variables [variable-name :FooType]}
-                            [:fooField]])))))
+               (core/unparse [:oksa/query {:variables [variable-name :FooType]}
+                              [:fooField]])))))
   (t/testing "aliases"
     (t/is (= "{bar:foo}"
            (core/unparse [[:foo {:alias "bar"}]])
@@ -189,13 +189,13 @@
                           [:qux {:alias :baz}]]))))
   (t/testing "directives"
     (t/is (= "query @foo{foo}"
-           (core/unparse [:query {:directives [:foo]} [:foo]])
-           (core/unparse [:query {:directives [[:foo]]} [:foo]])))
+             (core/unparse [:oksa/query {:directives [:foo]} [:foo]])
+             (core/unparse [:oksa/query {:directives [[:foo]]} [:foo]])))
     (t/is (= "query @foo @bar{foo}"
-           (core/unparse [:query {:directives [:foo :bar]} [:foo]])
-           (core/unparse [:query {:directives [[:foo] [:bar]]} [:foo]])))
+             (core/unparse [:oksa/query {:directives [:foo :bar]} [:foo]])
+             (core/unparse [:oksa/query {:directives [[:foo] [:bar]]} [:foo]])))
     (t/is (= "query @foo(bar:123){foo}"
-           (core/unparse [:query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])))
+             (core/unparse [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])))
     (t/is (= "{foo@bar}"
            (core/unparse [[:foo {:directives [:bar]}]])))
     (t/is (= "{foo@bar qux@baz}"
@@ -204,33 +204,33 @@
     (t/is (= "{foo@foo(bar:123)}"
            (core/unparse [[:foo {:directives [[:foo {:arguments {:bar 123}}]]}]])))
     (t/is (= "{...foo@fooDirective @barDirective}"
-           (core/unparse [[:fragment-spread {:name :foo
-                                             :directives [:fooDirective :barDirective]}]])))
+             (core/unparse [[:oksa/fragment-spread {:name :foo
+                                                    :directives [:fooDirective :barDirective]}]])))
     (t/is (= "{...foo@foo(bar:123)}"
-           (core/unparse [[:fragment-spread {:name :foo
-                                             :directives [[:foo {:arguments {:bar 123}}]]}]])))
+             (core/unparse [[:oksa/fragment-spread {:name :foo
+                                                    :directives [[:foo {:arguments {:bar 123}}]]}]])))
     (t/is (= "{...@fooDirective @barDirective{bar}}"
-           (core/unparse [[:inline-fragment {:directives [:fooDirective :barDirective]}
-                           [:bar]]])))
+             (core/unparse [[:oksa/inline-fragment {:directives [:fooDirective :barDirective]}
+                             [:bar]]])))
     (t/is (= "{...@foo(bar:123){bar}}"
-           (core/unparse [[:inline-fragment {:directives [[:foo {:arguments {:bar 123}}]]}
-                           [:bar]]])))
+             (core/unparse [[:oksa/inline-fragment {:directives [[:foo {:arguments {:bar 123}}]]}
+                             [:bar]]])))
     (t/is (= "fragment foo on Foo@foo(bar:123){bar}"
-           (core/unparse [:fragment {:name :foo
-                                     :on :Foo
-                                     :directives [[:foo {:arguments {:bar 123}}]]}
-                          [:bar]])))
+             (core/unparse [:oksa/fragment {:name :foo
+                                            :on :Foo
+                                            :directives [[:foo {:arguments {:bar 123}}]]}
+                            [:bar]])))
     (t/is (= "fragment foo on Foo@fooDirective @barDirective{bar}"
-           (core/unparse [:fragment {:name :foo
-                                     :on :Foo
-                                     :directives [:fooDirective :barDirective]}
-                          [:bar]])))
+             (core/unparse [:oksa/fragment {:name :foo
+                                            :on :Foo
+                                            :directives [:fooDirective :barDirective]}
+                            [:bar]])))
     (t/is (= "query ($foo:Bar @fooDirective){fooField}"
-           (core/unparse [:query {:variables [:foo {:directives [:fooDirective]} :Bar]}
-                          [:fooField]])))
+             (core/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]}
+                            [:fooField]])))
     (t/is (= "query ($foo:Bar @fooDirective @barDirective){fooField}"
-           (core/unparse [:query {:variables [:foo {:directives [:fooDirective :barDirective]} :Bar]}
-                          [:fooField]])))
+             (core/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective :barDirective]} :Bar]}
+                            [:fooField]])))
     (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
-           (core/unparse [:query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
-                          [:fooField]])))))
+             (core/unparse [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
+                            [:fooField]])))))


### PR DESCRIPTION
This resolves the problem where reserved keys are being rejected as faulty syntax despite being valid selection set fields.

Example:

```clojure
user=> (core/unparse [:bar [:qux [:baz]]])
"{bar{qux{baz}}}"

user=> (core/unparse [:query [:qux [:baz]]])
"query {qux{baz}}"

user=> (core/unparse [:query [:query [:baz]]])
Execution error (ExceptionInfo) at oksa.parse/parse (parse.cljc:233).
invalid form
```

The solution is to use `:oksa/` prefix for documents, queries, fragments, fragment definitions etc. so all of these become something akin to `:oksa/query` instead.

Using shortcuts like `:...` or `:<>` without a prefix should still be okay since they can't be ambiguated with field names.