### PR TITLE
Validate graphql using Java GraphQL parser

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,10 +5,12 @@
                   :extra-deps {lambdaisland/kaocha {:mvn/version "1.82.1306"}
                                lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
-                               com.graphql-java/graphql-java {:mvn/version "20.7"}}}
+                               com.graphql-java/graphql-java {:mvn/version "20.7"}
+                               cljsjs/graphql {:mvn/version "0.13.1-0"}}}
            :test-cljs {:extra-paths ["test"]
                        :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
-                                    org.clojure/clojurescript {:mvn/version "1.11.57"}}
+                                    org.clojure/clojurescript {:mvn/version "1.11.57"}
+                                    cljsjs/graphql {:mvn/version "0.13.1-0"}}
                        :main-opts ["-m" "cljs-test-runner.main"]}
            :clojure-10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :clojure-11 {}

--- a/deps.edn
+++ b/deps.edn
@@ -5,12 +5,10 @@
                   :extra-deps {lambdaisland/kaocha {:mvn/version "1.82.1306"}
                                lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
-                               com.graphql-java/graphql-java {:mvn/version "20.7"}
-                               cljsjs/graphql {:mvn/version "0.13.1-0"}}}
+                               com.graphql-java/graphql-java {:mvn/version "20.7"}}}
            :test-cljs {:extra-paths ["test"]
                        :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
-                                    org.clojure/clojurescript {:mvn/version "1.11.57"}
-                                    cljsjs/graphql {:mvn/version "0.13.1-0"}}
+                                    org.clojure/clojurescript {:mvn/version "1.11.57"}}
                        :main-opts ["-m" "cljs-test-runner.main"]}
            :clojure-10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :clojure-11 {}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,8 @@
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {lambdaisland/kaocha {:mvn/version "1.82.1306"}
                                lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}
-                               lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}}
+                               lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
+                               com.graphql-java/graphql-java {:mvn/version "20.7"}}}
            :test-cljs {:extra-paths ["test"]
                        :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
                                     org.clojure/clojurescript {:mvn/version "1.11.57"}}

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -1,256 +1,263 @@
 (ns oksa.core-test
   (:require [#?(:clj clojure.test
                 :cljs cljs.test) :as t]
-            [oksa.core :as core]))
+            [oksa.core :as core])
+  (:import [graphql.parser Parser]))
+
+(defn unparse-and-validate
+  [x]
+  (let [graphql-query (core/unparse x)]
+    #?(:clj (Parser/parse graphql-query))
+    graphql-query))
 
 (t/deftest unparse-test
   (t/testing "query"
-    (t/is (= "query {foo}" (core/unparse [:oksa/query {} [:foo]])))
-    (t/is (= "query {foo bar}" (core/unparse [:oksa/query {} [:foo :bar]])))
-    (t/is (= "query {bar{qux{baz}}}" (core/unparse [:oksa/query {} [:bar [:qux [:baz]]]])))
-    (t/is (= "query {foo bar{qux{baz}}}" (core/unparse [:oksa/query {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "query Foo {foo}" (core/unparse [:oksa/query {:name :Foo} [:foo]])))
+    (t/is (= "query {foo}" (unparse-and-validate [:oksa/query {} [:foo]])))
+    (t/is (= "query {foo bar}" (unparse-and-validate [:oksa/query {} [:foo :bar]])))
+    (t/is (= "query {bar{qux{baz}}}" (unparse-and-validate [:oksa/query {} [:bar [:qux [:baz]]]])))
+    (t/is (= "query {foo bar{qux{baz}}}" (unparse-and-validate [:oksa/query {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "query Foo {foo}" (unparse-and-validate [:oksa/query {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/query [:oksa/query [:baz]]])))
-      (t/is (= "query {query{baz}}" (core/unparse [:oksa/query [:query [:baz]]])))
-      (t/is (= "{query{query{baz}}}" (core/unparse [:query [:query [:baz]]])))))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [:oksa/query [:oksa/query [:baz]]])))
+      (t/is (= "query {query{baz}}" (unparse-and-validate [:oksa/query [:query [:baz]]])))
+      (t/is (= "{query{query{baz}}}" (unparse-and-validate [:query [:query [:baz]]])))))
   (t/testing "mutation"
-    (t/is (= "mutation {foo}" (core/unparse [:oksa/mutation {} [:foo]])))
-    (t/is (= "mutation {foo bar}" (core/unparse [:oksa/mutation {} [:foo :bar]])))
-    (t/is (= "mutation {bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:bar [:qux [:baz]]]])))
-    (t/is (= "mutation {foo bar{qux{baz}}}" (core/unparse [:oksa/mutation {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "mutation Foo {foo}" (core/unparse [:oksa/mutation {:name :Foo} [:foo]])))
+    (t/is (= "mutation {foo}" (unparse-and-validate [:oksa/mutation {} [:foo]])))
+    (t/is (= "mutation {foo bar}" (unparse-and-validate [:oksa/mutation {} [:foo :bar]])))
+    (t/is (= "mutation {bar{qux{baz}}}" (unparse-and-validate [:oksa/mutation {} [:bar [:qux [:baz]]]])))
+    (t/is (= "mutation {foo bar{qux{baz}}}" (unparse-and-validate [:oksa/mutation {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "mutation Foo {foo}" (unparse-and-validate [:oksa/mutation {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/mutation [:oksa/mutation [:baz]]])))
-      (t/is (= "mutation {mutation{baz}}" (core/unparse [:oksa/mutation [:mutation [:baz]]])))
-      (t/is (= "{mutation{mutation{baz}}}" (core/unparse [:mutation [:mutation [:baz]]])))))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [:oksa/mutation [:oksa/mutation [:baz]]])))
+      (t/is (= "mutation {mutation{baz}}" (unparse-and-validate [:oksa/mutation [:mutation [:baz]]])))
+      (t/is (= "{mutation{mutation{baz}}}" (unparse-and-validate [:mutation [:mutation [:baz]]])))))
   (t/testing "subscription"
-    (t/is (= "subscription {foo}" (core/unparse [:oksa/subscription {} [:foo]])))
-    (t/is (= "subscription {foo bar}" (core/unparse [:oksa/subscription {} [:foo :bar]])))
-    (t/is (= "subscription {bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:bar [:qux [:baz]]]])))
-    (t/is (= "subscription {foo bar{qux{baz}}}" (core/unparse [:oksa/subscription {} [:foo :bar [:qux [:baz]]]])))
-    (t/is (= "subscription Foo {foo}" (core/unparse [:oksa/subscription {:name :Foo} [:foo]])))
+    (t/is (= "subscription {foo}" (unparse-and-validate [:oksa/subscription {} [:foo]])))
+    (t/is (= "subscription {foo bar}" (unparse-and-validate [:oksa/subscription {} [:foo :bar]])))
+    (t/is (= "subscription {bar{qux{baz}}}" (unparse-and-validate [:oksa/subscription {} [:bar [:qux [:baz]]]])))
+    (t/is (= "subscription {foo bar{qux{baz}}}" (unparse-and-validate [:oksa/subscription {} [:foo :bar [:qux [:baz]]]])))
+    (t/is (= "subscription Foo {foo}" (unparse-and-validate [:oksa/subscription {:name :Foo} [:foo]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/subscription [:oksa/subscription [:baz]]])))
-      (t/is (= "subscription {subscription{baz}}" (core/unparse [:oksa/subscription [:subscription [:baz]]])))
-      (t/is (= "{subscription{subscription{baz}}}" (core/unparse [:subscription [:subscription [:baz]]])))))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [:oksa/subscription [:oksa/subscription [:baz]]])))
+      (t/is (= "subscription {subscription{baz}}" (unparse-and-validate [:oksa/subscription [:subscription [:baz]]])))
+      (t/is (= "{subscription{subscription{baz}}}" (unparse-and-validate [:subscription [:subscription [:baz]]])))))
   (t/testing "selection set"
     (t/is (= "{foo}"
-           (core/unparse [:foo])))
+             (unparse-and-validate [:foo])))
     (t/is (= "{foo bar}"
-           (core/unparse [:foo :bar])))
+             (unparse-and-validate [:foo :bar])))
     (t/is (= "{bar{qux{baz}}}"
-           (core/unparse [:bar [:qux [:baz]]])))
+             (unparse-and-validate [:bar [:qux [:baz]]])))
     (t/is (= "{foo bar{qux{baz}}}"
-           (core/unparse [:foo :bar [:qux [:baz]]])))
+             (unparse-and-validate [:foo :bar [:qux [:baz]]])))
     (t/is (= "{foo bar{qux baz}}"
-           (core/unparse [:foo :bar [:qux :baz]])))
+             (unparse-and-validate [:foo :bar [:qux :baz]])))
     (t/is (= "{foo{bar{baz qux} frob}}"
-           (core/unparse [:foo [:bar [:baz :qux] :frob]])))
+             (unparse-and-validate [:foo [:bar [:baz :qux] :frob]])))
     (t/testing "support strings as field names"
       (t/is (= "{foo}"
-             (core/unparse ["foo"])
-             (core/unparse [:foo]))))
+               (unparse-and-validate ["foo"])
+               (unparse-and-validate [:foo]))))
     (t/testing "arguments"
       (t/is (= "{foo}"
-             (core/unparse [[:foo {:arguments {}}]])))
+               (unparse-and-validate [[:foo {:arguments {}}]])))
       (t/is (= "{foo(a:1, b:\"hello world\", c:true, d:null, e:foo, f:[1 2 3], g:{frob:{foo:1, bar:2}}, h:$fooVar)}"
-               (core/unparse [[:foo {:arguments {:a 1
-                                                 :b "hello world"
-                                                 :c true
-                                                 :d nil
-                                                 :e :foo
-                                                 :f [1 2 3]
-                                                 :g {:frob {:foo 1
-                                                            :bar 2}}
-                                                 :h :$fooVar}}]])))
+               (unparse-and-validate [[:foo {:arguments {:a 1
+                                                         :b "hello world"
+                                                         :c true
+                                                         :d nil
+                                                         :e :foo
+                                                         :f [1 2 3]
+                                                         :g {:frob {:foo 1
+                                                                    :bar 2}}
+                                                         :h :$fooVar}}]])))
       #?(:clj (t/is (= "{foo(a:0.3333333333333333)}"
-                       (core/unparse [[:foo {:arguments {:a 1/3}}]]))))
+                       (unparse-and-validate [[:foo {:arguments {:a 1/3}}]]))))
       (t/testing "escaping special characters"
         (t/is (= "{fooField(foo:\"\\\"\")}"
-               (core/unparse [[:fooField {:arguments {:foo "\""}}]])))
+                 (unparse-and-validate [[:fooField {:arguments {:foo "\""}}]])))
         (t/is (= "{fooField(foo:\"\\\\\")}"
-               (core/unparse [[:fooField {:arguments {:foo "\\"}}]])))
+                 (unparse-and-validate [[:fooField {:arguments {:foo "\\"}}]])))
         (t/is (= "{fooField(foo:\"foo\\b\\f\\r\\n\\tbar\")}"
-               (core/unparse [[:fooField {:arguments {:foo (str "foo\b\f\r\n\tbar")}}]]))))))
+                 (unparse-and-validate [[:fooField {:arguments {:foo (str "foo\b\f\r\n\tbar")}}]]))))))
   (t/testing "document"
     (t/is (= "{foo}"
-             (core/unparse [:<> [:foo]])
-             (core/unparse [:oksa/document [:foo]])))
+             (unparse-and-validate [:<> [:foo]])
+             (unparse-and-validate [:oksa/document [:foo]])))
     (t/is (= "{foo}\n{bar}"
-             (core/unparse [:<> [:foo] [:bar]])
-             (core/unparse [:oksa/document [:foo] [:bar]])))
+             (unparse-and-validate [:<> [:foo] [:bar]])
+             (unparse-and-validate [:oksa/document [:foo] [:bar]])))
     (t/is (= "{foo}\nquery {bar}\nmutation {qux}\nsubscription {baz}\nfragment foo on Foo{bar}"
-             (core/unparse [:<>
-                            [:foo]
-                            [:oksa/query [:bar]]
-                            [:oksa/mutation [:qux]]
-                            [:oksa/subscription [:baz]]
-                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
-             (core/unparse [:oksa/document
-                            [:foo]
-                            [:oksa/query [:bar]]
-                            [:oksa/mutation [:qux]]
-                            [:oksa/subscription [:baz]]
-                            [:oksa/fragment {:name :foo :on :Foo} [:bar]]])))
+             (unparse-and-validate [:<>
+                                    [:foo]
+                                    [:oksa/query [:bar]]
+                                    [:oksa/mutation [:qux]]
+                                    [:oksa/subscription [:baz]]
+                                    [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
+             (unparse-and-validate [:oksa/document
+                                    [:foo]
+                                    [:oksa/query [:bar]]
+                                    [:oksa/mutation [:qux]]
+                                    [:oksa/subscription [:baz]]
+                                    [:oksa/fragment {:name :foo :on :Foo} [:bar]]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/document [:oksa/document [:baz]]])))
-      (t/is (= "{document{baz}}" (core/unparse [:oksa/document [:document [:baz]]])))
-      (t/is (= "{document{document{baz}}}" (core/unparse [:document [:document [:baz]]])))))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [:oksa/document [:oksa/document [:baz]]])))
+      (t/is (= "{document{baz}}" (unparse-and-validate [:oksa/document [:document [:baz]]])))
+      (t/is (= "{document{document{baz}}}" (unparse-and-validate [:document [:document [:baz]]])))))
   (t/testing "fragment"
     (t/is (= "fragment Foo on Bar{foo}"
-             (core/unparse [:# {:name :Foo :on :Bar} [:foo]])
-             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo]])))
+             (unparse-and-validate [:# {:name :Foo :on :Bar} [:foo]])
+             (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:foo]])))
     (t/is (= "fragment Foo on Bar{foo bar}"
-             (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar]])
-             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar]])))
+             (unparse-and-validate [:# {:name :Foo :on :Bar} [:foo :bar]])
+             (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar]])))
     (t/is (= "fragment Foo on Bar{bar{qux{baz}}}"
-             (core/unparse [:# {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])
-             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])))
+             (unparse-and-validate [:# {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])
+             (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:bar [:qux [:baz]]]])))
     (t/is (= "fragment Foo on Bar{foo bar{qux{baz}}}"
-             (core/unparse [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
-             (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])))
+             (unparse-and-validate [:# {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])
+             (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:foo :bar [:qux [:baz]]]])))
     (t/testing "non-ambiguity"
-      (t/is (thrown? #?(:clj Exception :cljs js/Error) (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:oksa/fragment {:name :Foo :on :Bar} [:baz]]])))
-      (t/is (= "fragment Foo on Bar{fragment{baz}}" (core/unparse [:oksa/fragment {:name :Foo :on :Bar} [:fragment [:baz]]])))
-      (t/is (= "{fragment{fragment{baz}}}" (core/unparse [:fragment [:fragment [:baz]]])))))
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:oksa/fragment {:name :Foo :on :Bar} [:baz]]])))
+      (t/is (= "fragment Foo on Bar{fragment{baz}}" (unparse-and-validate [:oksa/fragment {:name :Foo :on :Bar} [:fragment [:baz]]])))
+      (t/is (= "{fragment{fragment{baz}}}" (unparse-and-validate [:fragment [:fragment [:baz]]])))))
   (t/testing "fragment spread"
     (t/is (= "{foo ...bar}"
-             (core/unparse [:foo [:... {:name :bar}]])
-             (core/unparse [:foo [:oksa/fragment-spread {:name :bar}]]))))
+             (unparse-and-validate [:foo [:... {:name :bar}]])
+             (unparse-and-validate [:foo [:oksa/fragment-spread {:name :bar}]]))))
   (t/testing "inline fragment"
     (t/is (= "{foo ...{bar}}"
-             (core/unparse [:foo [:... [:bar]]])
-             (core/unparse [:foo [:oksa/inline-fragment [:bar]]])))
+             (unparse-and-validate [:foo [:... [:bar]]])
+             (unparse-and-validate [:foo [:oksa/inline-fragment [:bar]]])))
     (t/is (= "{foo ...on Bar{bar}}"
-             (core/unparse [:foo [:... {:on :Bar} [:bar]]])
-             (core/unparse [:foo [:oksa/inline-fragment {:on :Bar} [:bar]]]))))
+             (unparse-and-validate [:foo [:... {:on :Bar} [:bar]]])
+             (unparse-and-validate [:foo [:oksa/inline-fragment {:on :Bar} [:bar]]]))))
   (t/testing "variable definitions"
     (t/testing "named type"
       (t/is (= "query ($fooVar:FooType){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar :FooType]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar :FooType]}
+                                      [:fooField]]))))
     (t/testing "non-null named type")
     (t/is (= "query ($fooVar:FooType!){fooField}"
-             (core/unparse [:oksa/query {:variables [:fooVar [:FooType {:non-null true}]]}
-                            [:fooField]])))
+             (unparse-and-validate [:oksa/query {:variables [:fooVar [:FooType {:non-null true}]]}
+                                    [:fooField]])))
     (t/testing "named type within list"
       (t/is (= "query ($fooVar:[FooType]){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list :FooType]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [:FooType]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list :FooType]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:FooType]]}
+                                      [:fooField]]))))
     (t/testing "non-null named type within list"
       (t/is (= "query ($fooVar:[FooType!]){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list
-                                                                [:FooType {:non-null true}]]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [:FooType!]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list
+                                                                        [:FooType {:non-null true}]]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:FooType!]]}
+                                      [:fooField]]))))
     (t/testing "named type within list"
       (t/is (= "query ($fooVar:[BarType]!){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                                :BarType]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [:! :BarType]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                        :BarType]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:! :BarType]]}
+                                      [:fooField]]))))
     (t/testing "non-null type within non-null list"
       (t/is (= "query ($fooVar:[BarType!]!){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                                [:BarType {:non-null true}]]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [:! :BarType!]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                        [:BarType {:non-null true}]]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:! :BarType!]]}
+                                      [:fooField]]))))
     (t/testing "named type within list within list"
       (t/is (= "query ($fooVar:[[BarType]]){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list
-                                                                [:oksa/list
-                                                                 :BarType]]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [[:BarType]]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list
+                                                                        [:oksa/list
+                                                                         :BarType]]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [[:BarType]]]}
+                                      [:fooField]]))))
     (t/testing "non-null list within non-null list"
       (t/is (= "query ($fooVar:[[BarType]!]!){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
-                                                                [:oksa/list {:non-null true}
-                                                                 :BarType]]]}
-                              [:fooField]])
-               (core/unparse [:oksa/query {:variables [:fooVar [:! [:! :BarType]]]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true}
+                                                                        [:oksa/list {:non-null true}
+                                                                         :BarType]]]}
+                                      [:fooField]])
+               (unparse-and-validate [:oksa/query {:variables [:fooVar [:! [:! :BarType]]]}
+                                      [:fooField]]))))
     (t/testing "multiple variable definitions"
       (t/is (= "query ($fooVar:FooType,$barVar:BarType){fooField}"
-               (core/unparse [:oksa/query {:variables [:fooVar :FooType
-                                                       :barVar :BarType]}
-                              [:fooField]]))))
+               (unparse-and-validate [:oksa/query {:variables [:fooVar :FooType
+                                                               :barVar :BarType]}
+                                      [:fooField]]))))
     (t/testing "default values"
       (t/is (= "query ($fooVar:Foo=123){fooField(foo:$fooVar)}"
-               (core/unparse [:oksa/query {:variables [:$fooVar {:default 123} :Foo]}
-                              [[:fooField {:arguments {:foo :$fooVar}}]]])))))
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 123} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))))
   (t/testing "variable names"
     (doseq [variable-name [:fooVar :$fooVar "fooVar" "$fooVar"]]
       (t/is (= "query ($fooVar:FooType){fooField}"
-               (core/unparse [:oksa/query {:variables [variable-name :FooType]}
-                              [:fooField]])))))
+               (unparse-and-validate [:oksa/query {:variables [variable-name :FooType]}
+                                      [:fooField]])))))
   (t/testing "aliases"
     (t/is (= "{bar:foo}"
-           (core/unparse [[:foo {:alias "bar"}]])
-           (core/unparse [[:foo {:alias :bar}]])))
+             (unparse-and-validate [[:foo {:alias "bar"}]])
+             (unparse-and-validate [[:foo {:alias :bar}]])))
     (t/is (= "{bar:foo baz:qux}"
-           (core/unparse [[:foo {:alias "bar"}]
-                          [:qux {:alias "baz"}]])
-           (core/unparse [[:foo {:alias :bar}]
-                          [:qux {:alias :baz}]])))
+             (unparse-and-validate [[:foo {:alias "bar"}]
+                                    [:qux {:alias "baz"}]])
+             (unparse-and-validate [[:foo {:alias :bar}]
+                                    [:qux {:alias :baz}]])))
     (t/is (= "{bar:foo frob baz:qux}"
-           (core/unparse [[:foo {:alias "bar"}]
-                          :frob
-                          [:qux {:alias "baz"}]])
-           (core/unparse [[:foo {:alias :bar}]
-                          :frob
-                          [:qux {:alias :baz}]]))))
+             (unparse-and-validate [[:foo {:alias "bar"}]
+                                    :frob
+                                    [:qux {:alias "baz"}]])
+             (unparse-and-validate [[:foo {:alias :bar}]
+                                    :frob
+                                    [:qux {:alias :baz}]]))))
   (t/testing "directives"
     (t/is (= "query @foo{foo}"
-             (core/unparse [:oksa/query {:directives [:foo]} [:foo]])
-             (core/unparse [:oksa/query {:directives [[:foo]]} [:foo]])))
+             (unparse-and-validate [:oksa/query {:directives [:foo]} [:foo]])
+             (unparse-and-validate [:oksa/query {:directives [[:foo]]} [:foo]])))
     (t/is (= "query @foo @bar{foo}"
-             (core/unparse [:oksa/query {:directives [:foo :bar]} [:foo]])
-             (core/unparse [:oksa/query {:directives [[:foo] [:bar]]} [:foo]])))
+             (unparse-and-validate [:oksa/query {:directives [:foo :bar]} [:foo]])
+             (unparse-and-validate [:oksa/query {:directives [[:foo] [:bar]]} [:foo]])))
     (t/is (= "query @foo(bar:123){foo}"
-             (core/unparse [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])))
+             (unparse-and-validate [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])))
     (t/is (= "{foo@bar}"
-           (core/unparse [[:foo {:directives [:bar]}]])))
+             (unparse-and-validate [[:foo {:directives [:bar]}]])))
     (t/is (= "{foo@bar qux@baz}"
-           (core/unparse [[:foo {:directives [:bar]}]
-                          [:qux {:directives [:baz]}]])))
+             (unparse-and-validate [[:foo {:directives [:bar]}]
+                                    [:qux {:directives [:baz]}]])))
     (t/is (= "{foo@foo(bar:123)}"
-           (core/unparse [[:foo {:directives [[:foo {:arguments {:bar 123}}]]}]])))
+             (unparse-and-validate [[:foo {:directives [[:foo {:arguments {:bar 123}}]]}]])))
     (t/is (= "{...foo@fooDirective @barDirective}"
-             (core/unparse [[:oksa/fragment-spread {:name :foo
-                                                    :directives [:fooDirective :barDirective]}]])))
+             (unparse-and-validate [[:oksa/fragment-spread {:name :foo
+                                                            :directives [:fooDirective :barDirective]}]])))
     (t/is (= "{...foo@foo(bar:123)}"
-             (core/unparse [[:oksa/fragment-spread {:name :foo
-                                                    :directives [[:foo {:arguments {:bar 123}}]]}]])))
+             (unparse-and-validate [[:oksa/fragment-spread {:name :foo
+                                                            :directives [[:foo {:arguments {:bar 123}}]]}]])))
     (t/is (= "{...@fooDirective @barDirective{bar}}"
-             (core/unparse [[:oksa/inline-fragment {:directives [:fooDirective :barDirective]}
-                             [:bar]]])))
+             (unparse-and-validate [[:oksa/inline-fragment {:directives [:fooDirective :barDirective]}
+                                     [:bar]]])))
     (t/is (= "{...@foo(bar:123){bar}}"
-             (core/unparse [[:oksa/inline-fragment {:directives [[:foo {:arguments {:bar 123}}]]}
-                             [:bar]]])))
+             (unparse-and-validate [[:oksa/inline-fragment {:directives [[:foo {:arguments {:bar 123}}]]}
+                                     [:bar]]])))
     (t/is (= "fragment foo on Foo@foo(bar:123){bar}"
-             (core/unparse [:oksa/fragment {:name :foo
-                                            :on :Foo
-                                            :directives [[:foo {:arguments {:bar 123}}]]}
-                            [:bar]])))
+             (unparse-and-validate [:oksa/fragment {:name :foo
+                                                    :on :Foo
+                                                    :directives [[:foo {:arguments {:bar 123}}]]}
+                                    [:bar]])))
     (t/is (= "fragment foo on Foo@fooDirective @barDirective{bar}"
-             (core/unparse [:oksa/fragment {:name :foo
-                                            :on :Foo
-                                            :directives [:fooDirective :barDirective]}
-                            [:bar]])))
+             (unparse-and-validate [:oksa/fragment {:name :foo
+                                                    :on :Foo
+                                                    :directives [:fooDirective :barDirective]}
+                                    [:bar]])))
     (t/is (= "query ($foo:Bar @fooDirective){fooField}"
-             (core/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]}
-                            [:fooField]])))
+             (unparse-and-validate [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]}
+                                    [:fooField]])))
     (t/is (= "query ($foo:Bar @fooDirective @barDirective){fooField}"
-             (core/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective :barDirective]} :Bar]}
-                            [:fooField]])))
+             (unparse-and-validate [:oksa/query {:variables [:foo {:directives [:fooDirective :barDirective]} :Bar]}
+                                    [:fooField]])))
     (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
-             (core/unparse [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
-                            [:fooField]])))))
+             (unparse-and-validate [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
+                                    [:fooField]])))))

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -1,15 +1,13 @@
 (ns oksa.core-test
   (:require [#?(:clj clojure.test
                 :cljs cljs.test) :as t]
-            [oksa.core :as core]
-            #?(:cljs [cljsjs.graphql :as graphql]))
-  #?(:clj (:import [graphql.parser Parser])))
+            [oksa.core :as core])
+  (:import [graphql.parser Parser]))
 
 (defn unparse-and-validate
   [x]
   (let [graphql-query (core/unparse x)]
     #?(:clj (Parser/parse graphql-query))
-    #?(:cljs (graphql/parse graphql-query))
     graphql-query))
 
 (t/deftest unparse-test

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -2,7 +2,7 @@
   (:require [#?(:clj clojure.test
                 :cljs cljs.test) :as t]
             [oksa.core :as core])
-  (:import [graphql.parser Parser]))
+  #?(:clj (:import [graphql.parser Parser])))
 
 (defn unparse-and-validate
   [x]

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -1,13 +1,15 @@
 (ns oksa.core-test
   (:require [#?(:clj clojure.test
                 :cljs cljs.test) :as t]
-            [oksa.core :as core])
-  (:import [graphql.parser Parser]))
+            [oksa.core :as core]
+            #?(:cljs [cljsjs.graphql :as graphql]))
+  #?(:clj (:import [graphql.parser Parser])))
 
 (defn unparse-and-validate
   [x]
   (let [graphql-query (core/unparse x)]
     #?(:clj (Parser/parse graphql-query))
+    #?(:cljs (graphql/parse graphql-query))
     graphql-query))
 
 (t/deftest unparse-test


### PR DESCRIPTION
In this MR we start running the output of `oksa.core/unparse` against a Java GraphQL parser when running tests.

Was almost about to do it for cljs, but then I ran into a snag with cljs js library importing. Won't try to tackle this now.