### PR TITLE
Fixes default value formatting

### DIFF
--- a/src/oksa/unparse.cljc
+++ b/src/oksa/unparse.cljc
@@ -3,6 +3,8 @@
             [oksa.util :as util])
   #?(:clj (:import (clojure.lang Keyword PersistentVector PersistentArrayMap))))
 
+(defmulti format-value type)
+
 (defn- format-type
   [[type opts child]]
   (if (= :oksa/list type)
@@ -20,8 +22,8 @@
   (str (variable-name variable)
        ":"
        (format-type type)
-       (when (:default opts)
-         (str "=" (:default opts)))
+       (when (contains? opts :default)
+         (str "=" (format-value (:default opts))))
        (when (:directives opts)
          (str " " (format-directives (:directives opts))))))
 
@@ -57,7 +59,6 @@
                  \u000C "\\f"
                  \u000D "\\r"}))
 
-(defmulti format-value type)
 (defmethod format-value #?(:clj Number
                            :cljs js/Number) [x] (str x))
 #?(:clj (defmethod format-value clojure.lang.Ratio [x] (str (double x))))
@@ -75,7 +76,7 @@
 (defmethod format-value #?(:clj PersistentVector
                            :cljs cljs.core/PersistentVector)
   [x]
-  (str x))
+  (str "[" (clojure.string/join " " (mapv format-value x)) "]"))
 (defmethod format-value #?(:clj PersistentArrayMap
                            :cljs cljs.core/PersistentArrayMap)
   [x]

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -193,9 +193,10 @@
       (t/is (= "query ($fooVar:Foo=123){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 123} :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))
-      (t/is (= "query ($fooVar:Foo=0.3333333333333333){fooField(foo:$fooVar)}"
-               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 1/3} :Foo]}
-                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      #?(:clj
+         (t/is (= "query ($fooVar:Foo=0.3333333333333333){fooField(foo:$fooVar)}"
+                  (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 1/3} :Foo]}
+                                         [[:fooField {:arguments {:foo :$fooVar}}]]]))))
       (t/is (= "query ($fooVar:Foo=\"häkkyrä\"){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default "häkkyrä"} :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))
@@ -208,26 +209,24 @@
       (t/is (= "query ($fooVar:Foo=Frob){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default :Frob} :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))
-      (t/is (= "query ($fooVar:Foo=[1 0.3333333333333333 \"häkkyrä\" true null Bar [1 0.3333333333333333 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]] {foo:\"kikka\", bar:\"kukka\"}]){fooField(foo:$fooVar)}"
+      (t/is (= "query ($fooVar:Foo=[1 \"häkkyrä\" true null Bar [1 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]] {foo:\"kikka\", bar:\"kukka\"}]){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default [1
-                                                                                   1/3
                                                                                    "häkkyrä"
                                                                                    true
                                                                                    nil
                                                                                    :Bar
-                                                                                   [1 1/3 "häkkyrä" true nil :Bar ["foo" "bar"]]
+                                                                                   [1 "häkkyrä" true nil :Bar ["foo" "bar"]]
                                                                                    {:foo "kikka"
                                                                                     "bar" "kukka"}]}
                                                                :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))
-      (t/is (= "query ($fooVar:Foo={number:1, ratio:0.3333333333333333, string:\"häkkyrä\", boolean:true, default:null, keyword:Bar, coll:[1 0.3333333333333333 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]]}){fooField(foo:$fooVar)}"
+      (t/is (= "query ($fooVar:Foo={number:1, string:\"häkkyrä\", boolean:true, default:null, keyword:Bar, coll:[1 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]]}){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default {:number 1
-                                                                                   :ratio 1/3
                                                                                    :string "häkkyrä"
                                                                                    :boolean true
                                                                                    :default nil
                                                                                    :keyword :Bar
-                                                                                   :coll [1 1/3 "häkkyrä" true nil :Bar ["foo" "bar"]]}} :Foo]}
+                                                                                   :coll [1 "häkkyrä" true nil :Bar ["foo" "bar"]]}} :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))))
   (t/testing "variable names"
     (doseq [variable-name [:fooVar :$fooVar "fooVar" "$fooVar"]]

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -192,6 +192,42 @@
     (t/testing "default values"
       (t/is (= "query ($fooVar:Foo=123){fooField(foo:$fooVar)}"
                (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 123} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=0.3333333333333333){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default 1/3} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=\"häkkyrä\"){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default "häkkyrä"} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=true){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default true} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=null){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default nil} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=Frob){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default :Frob} :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo=[1 0.3333333333333333 \"häkkyrä\" true null Bar [1 0.3333333333333333 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]] {foo:\"kikka\", bar:\"kukka\"}]){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default [1
+                                                                                   1/3
+                                                                                   "häkkyrä"
+                                                                                   true
+                                                                                   nil
+                                                                                   :Bar
+                                                                                   [1 1/3 "häkkyrä" true nil :Bar ["foo" "bar"]]
+                                                                                   {:foo "kikka"
+                                                                                    "bar" "kukka"}]}
+                                                               :Foo]}
+                                      [[:fooField {:arguments {:foo :$fooVar}}]]])))
+      (t/is (= "query ($fooVar:Foo={number:1, ratio:0.3333333333333333, string:\"häkkyrä\", boolean:true, default:null, keyword:Bar, coll:[1 0.3333333333333333 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]]}){fooField(foo:$fooVar)}"
+               (unparse-and-validate [:oksa/query {:variables [:$fooVar {:default {:number 1
+                                                                                   :ratio 1/3
+                                                                                   :string "häkkyrä"
+                                                                                   :boolean true
+                                                                                   :default nil
+                                                                                   :keyword :Bar
+                                                                                   :coll [1 1/3 "häkkyrä" true nil :Bar ["foo" "bar"]]}} :Foo]}
                                       [[:fooField {:arguments {:foo :$fooVar}}]]])))))
   (t/testing "variable names"
     (doseq [variable-name [:fooVar :$fooVar "fooVar" "$fooVar"]]


### PR DESCRIPTION
Fixes #5 .

Couple things addressed here:
- Start applying `format-value` for default option
- Stop ignoring nil valued default option
- Add a whole bunch of missing tests to cover each `:oksa.parse/Value` type