### PR TITLE
Add programmatic API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,17 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 [breakver]: https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md
 
 Oksa is currently [experimental](https://github.com/topics/metosin-experimental).
+
+## 0.0.2-SNAPSHOT
+
+- Adds `oksa.core/explain` as a convenience function for `malli.core/explain`
+- Fixes default value formatting [#6](https://github.com/metosin/oksa/pull/6)
+- Introduces `oksa.alpha.api` for programmatic API access
+  [#7](https://github.com/metosin/oksa/pull/7)
+  - Restricts `FragmentDefinition` and `OperationDefinition` to have just
+    single SelectionSet as per spec
+  - Fixes `TypeName` to also support string-typed name
+
+## 0.0.1
+
+First release! 🎉

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Fragment definitions can be created:
 
 ```clojure
 (oksa/gql [:oksa/fragment {:name :Foo :on :Bar} [:foo]])
-(oksa/unparse [:# {:name :Foo :on :Bar} [:foo]]) ; shortcut
+(oksa/gql [:# {:name :Foo :on :Bar} [:foo]]) ; shortcut
 (oksa/gql (fragment (opts
                       (name :Foo)
                       (on :Bar))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Generate GraphQL queries using Clojure data structures.
 
 - Support latest stable [GraphQL spec](https://spec.graphql.org/October2021)
-- [Malli](https://github.com/metosin/malli)-like syntax
+- [Malli](https://github.com/metosin/malli)-like syntax or programmatic API
 - clojure + clojurescript
 
 ## Project status
@@ -29,8 +29,12 @@ Oksa is currently [experimental](https://github.com/topics/metosin-experimental)
 
 ```clojure
 (require '[oksa.core :as oksa])
-(oksa/unparse [:hello [:world]])
+(require '[oksa.alpha.api :refer :all])
+
+(oksa/gql [:hello [:world]])
 ;; => "{hello{world}}"
+
+(oksa/gql (select :hello (select :world)))
 ```
 
 ### Operation definitions
@@ -40,62 +44,101 @@ Oksa is currently [experimental](https://github.com/topics/metosin-experimental)
 Fields can be selected:
 
 ```clojure
-(oksa/unparse [:foo])
+(oksa/gql [:foo])
+(oksa/gql (select :foo))
 ;; => "{foo}"
 
-(oksa/unparse [:foo :bar])
+(oksa/gql [:foo :bar])
+(oksa/gql (select :foo :bar))
 ;; => "{foo bar}"
 
-(oksa/unparse [:bar [:qux [:baz]]])
+(oksa/gql [:bar [:qux [:baz]]])
+(oksa/gql (select
+            :bar
+            (select
+              :qux
+              (select :baz))))
 ;; => "{bar{qux{baz}}}"
 
-(oksa/unparse [:foo :bar [:qux [:baz]]])
+(oksa/gql [:foo :bar [:qux [:baz]]])
+(oksa/gql (select
+            :foo
+            :bar
+            (select
+              :qux
+              (select :baz))))
 ;; => "{foo bar{qux{baz}}}"
 
-(oksa/unparse [:foo :bar [:qux :baz]])
+(oksa/gql [:foo :bar [:qux :baz]])
+(oksa/gql (select
+            :foo
+            :bar
+            (select :qux :baz)))
 ;; => "{foo bar{qux baz}}"
 
-(oksa/unparse [:foo [:bar [:baz :qux] :frob]])
+(oksa/gql [:foo [:bar [:baz :qux] :frob]])
+(oksa/gql (select
+            :foo
+            (select
+              :bar
+              (select :baz :qux)
+              :frob)))
 ;; => "{foo{bar{baz qux} frob}}"
 ```
 
 Strings are supported for field names:
 
 ```clojure
-(oksa/unparse ["query" "foo"])
+(oksa/gql ["query" "foo"])
+(oksa/gql (select "query" "foo"))
 ;; => "{query foo}"
 ```
 
 Aliases:
 
 ```clojure
-(oksa/unparse [[:foo {:alias :bar}]])
+(oksa/gql [[:foo {:alias :bar}]])
+(oksa/gql (select (field :foo (opts (alias :bar)))))
 ;; => "{bar:foo}"
 ```
 
 Arguments:
 
 ```clojure
-(oksa/unparse [[:foo {:arguments {:a 1
-                                  :b "hello world"
-                                  :c true
-                                  :d nil
-                                  :e :foo
-                                  :f [1 2 3]
-                                  :g {:frob {:foo 1
-                                             :bar 2}}
-                                  :h :$fooVar}}]])
+(oksa/gql [[:foo {:arguments {:a 1
+                              :b "hello world"
+                              :c true
+                              :d nil
+                              :e :foo
+                              :f [1 2 3]
+                              :g {:frob {:foo 1
+                                         :bar 2}}
+                              :h :$fooVar}}]])
 ;; => "{foo(a:1, b:\"hello world\", c:true, d:null, e:foo, f:[1 2 3], g:{frob:{foo:1, bar:2}}, h:$fooVar)}"
+
+;; alt
+(oksa/gql (select (field :foo (opts (arguments
+                                      :a 1
+                                      :b "hello world"
+                                      :c true
+                                      :d nil
+                                      :e :foo
+                                      :f [1 2 3]
+                                      :g {:frob {:foo 1
+                                                 :bar 2}}
+                                      :h :$fooVar)))))
 ```
 
 Directives:
 
 ```clojure
-(oksa/unparse [[:foo {:directives [:bar]}]])
+(oksa/gql [[:foo {:directives [:bar]}]])
+(oksa/gql (select (field :foo (opts (directive :bar)))))
 ;; => "{foo@bar}"
 
 ;; with arguments
-(oksa/unparse [[:foo {:directives [[:bar {:arguments {:qux 123}}]]}]])
+(oksa/gql [[:foo {:directives [[:bar {:arguments {:qux 123}}]]}]])
+(oksa/gql (select (field :foo (opts (directive :bar (arguments :qux 123))))))
 ;; => "{foo@bar(qux:123)}"
 ```
 
@@ -104,25 +147,36 @@ Directives:
 Queries can be created:
 
 ```clojure
-(oksa/unparse [:oksa/query [:foo :bar [:qux [:baz]]]])
+(oksa/gql [:oksa/query [:foo :bar [:qux [:baz]]]])
+(oksa/gql (query
+            (select
+              :foo
+              :bar
+              (select
+                :qux
+                (select :baz)))))
 ;; => "query {foo bar{qux{baz}}}"
 
-(oksa/unparse [:oksa/query {:name :Foo} [:foo]])
+(oksa/gql [:oksa/query {:name :Foo} [:foo]])
+(oksa/gql (query (opts (name :Foo)) (select :foo)))
 ;; => "query Foo {foo}"
 ```
 
 Queries can have directives:
 
 ```clojure
-(oksa/unparse [:oksa/query {:directives [:foo]} [:foo]])
+(oksa/gql [:oksa/query {:directives [:foo]} [:foo]])
+(oksa/gql (query (opts (directive :foo)) (select :foo)))
 ;; => "query @foo{foo}"
 
-(oksa/unparse [:oksa/query {:directives [:foo :bar]} [:foo]])
+(oksa/gql [:oksa/query {:directives [:foo :bar]} [:foo]])
+(oksa/gql (query (opts (directives :foo :bar)) (select :foo)))
 ;; => "query @foo @bar{foo}"
 
 ;; with arguments
 
-(oksa/unparse [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])
+(oksa/gql [:oksa/query {:directives [[:foo {:arguments {:bar 123}}]]} [:foo]])
+(oksa/gql (query (opts (directive :foo (arguments :bar 123))) (select :foo)))
 ;; => "query @foo(bar:123){foo}"
 ```
 
@@ -131,10 +185,17 @@ Queries can have directives:
 Mutations can be created:
 
 ```clojure
-(oksa/unparse [:oksa/mutation [:foo :bar [:qux [:baz]]]])
+(oksa/gql [:oksa/mutation [:foo :bar [:qux [:baz]]]])
+(oksa/gql (mutation (select
+                      :foo
+                      :bar
+                      (select
+                        :qux
+                        (select :baz)))))
 ;; => "mutation {foo bar{qux{baz}}}"
 
-(oksa/unparse [:oksa/mutation {:name :Foo} [:foo]])
+(oksa/gql [:oksa/mutation {:name :Foo} [:foo]])
+(oksa/gql (mutation (opts (name :Foo)) (select :foo)))
 ;; => "mutation Foo {foo}"
 ```
 
@@ -143,10 +204,18 @@ Mutations can be created:
 Subscriptions can be created:
 
 ```clojure
-(oksa/unparse [:oksa/subscription [:foo :bar [:qux [:baz]]]])
+(oksa/gql [:oksa/subscription [:foo :bar [:qux [:baz]]]])
+(oksa/gql (subscription (select
+                          :foo
+                          :bar
+                          (select
+                            :qux
+                            (select :baz)))))
 ;; => "subscription {foo bar{qux{baz}}}"
 
-(oksa/unparse [:oksa/subscription {:name :Foo} [:foo]])
+(oksa/gql [:oksa/subscription {:name :Foo} [:foo]])
+(oksa/gql (subscription (opts (name :Foo))
+            (select :foo)))
 ;; => "subscription Foo {foo}"
 ```
 
@@ -155,86 +224,69 @@ Subscriptions can be created:
 Named types are supported:
 
 ```clojure
-(oksa/unparse [:oksa/query {:variables [:fooVar :FooType]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar :FooType]} [:fooField]])
+(oksa/gql (query (opts (variables :fooVar :FooType))
+            (select :fooField)))
 ;; => "query ($fooVar:FooType){fooField}"
 
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar :FooType
-                             :barVar :BarType]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar :FooType :barVar :BarType]} [:fooField]])
+(oksa/gql (query (opts (variables :fooVar :FooType :barVar :BarType))
+            (select :fooField)))
 ;; => "query ($fooVar:FooType,$barVar:BarType){fooField}"
 ```
 
 Lists can be created:
 
 ```clojure
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar [:oksa/list :FooType]]}
-               [:fooField]])
-
-;; or
-
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar [:FooType]]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:oksa/list :FooType]]} [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:FooType]]} [:fooField]])
+(oksa/gql (query (opts (variable :fooVar (list :FooType)))
+            (select :fooField)))
 ;; => "query ($fooVar:[FooType]){fooField}"
 
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar [:oksa/list
-                                      [:oksa/list
-                                       :BarType]]]}
-               [:fooField]])
-
-;; or
-
-(oksa/unparse [:oksa/query {:variables [:fooVar [[:BarType]]]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:oksa/list [:oksa/list :BarType]]]} [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [[:BarType]]]} [:fooField]])
+(oksa/gql (query (opts (variable :fooVar (list (list :BarType))))
+            (select :fooField)))
 ;; => "query ($fooVar:[[BarType]]){fooField}"
 ```
 
 Non-null types can be created:
 
 ```clojure
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar [:FooType {:non-null true}]]}
-               [:fooField]])
-
-;; or
-
-(oksa/unparse [:oksa/query {:variables [:fooVar :FooType!]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:FooType {:non-null true}]]} [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar :FooType!]} [:fooField]])
+(oksa/gql (query (opts (variable :fooVar (type! :FooType)))
+            (select :fooField)))
 ;; => "query ($fooVar:FooType!){fooField}"
 
-(oksa/unparse [:oksa/query {:variables
-                            [:fooVar [:oksa/list {:non-null true}
-                                      :BarType]]}
-               [:fooField]])
-
-;; or
-
-(oksa/unparse [:oksa/query {:variables [:fooVar [:! :BarType]]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:oksa/list {:non-null true} :BarType]]} [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:! :BarType]]} [:fooField]])
+(oksa/gql (query (opts (variable :fooVar (list! :BarType)))
+            (select :fooField)))
 ;; => "query ($fooVar:[BarType]!){fooField}"
 ```
 
 Getting crazy with it:
 
 ```clojure
-(oksa/unparse [:oksa/query {:variables [:fooVar [:! [:! :BarType!]]]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:fooVar [:! [:! :BarType!]]]} [:fooField]])
+(oksa/gql (query (opts (variable :fooVar (list! (list! (type! :BarType)))))
+            (select :fooField)))
 ;; => "query ($fooVar:[[BarType!]!]!){fooField}"
 ```
 
 Variable definitions can have directives:
 
 ```clojure
-(oksa/unparse [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:foo {:directives [:fooDirective]} :Bar]} [:fooField]])
+(oksa/gql (query (opts (variable :foo (opts (directive :fooDirective)) :Bar))
+            (select :fooField)))
 ;; => "query ($foo:Bar @fooDirective){fooField}"
 
-(oksa/unparse [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
-               [:fooField]])
+(oksa/gql [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]} [:fooField]])
+(oksa/gql (query (opts (variable :foo (opts (directive :fooDirective (argument :fooArg 123))) :Bar))
+            (select :fooField)))
 ;; => "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
 ```
 
@@ -243,67 +295,83 @@ Variable definitions can have directives:
 Fragment definitions can be created:
 
 ```clojure
-(oksa/unparse [:oksa/fragment {:name :Foo :on :Bar} [:foo]])
-;; => "fragment Foo on Bar{foo}"
-
+(oksa/gql [:oksa/fragment {:name :Foo :on :Bar} [:foo]])
 (oksa/unparse [:# {:name :Foo :on :Bar} [:foo]]) ; shortcut
+(oksa/gql (fragment (opts
+                      (name :Foo)
+                      (on :Bar))
+            (select :foo)))
 ;; => "fragment Foo on Bar{foo}"
 
 ;; with directives
-(oksa/unparse [:oksa/fragment {:name :foo
-                               :on :Foo
-                               :directives [:fooDirective]}
-               [:bar]])
+(oksa/gql [:oksa/fragment {:name :foo
+                           :on :Foo
+                           :directives [:fooDirective]}
+           [:bar]])
+; alt
+(oksa/gql (fragment (opts
+                      (name :foo)
+                      (on :Foo)
+                      (directive :fooDirective))
+            (select :bar)))
 ;; => "fragment foo on Foo@fooDirective{bar}"
 
 ;; with arguments
-(oksa/unparse [:oksa/fragment {:name :foo
-                               :on :Foo
-                               :directives [[:fooDirective {:arguments {:bar 123}}]]}
-               [:bar]])
+(oksa/gql [:oksa/fragment {:name :foo
+                           :on :Foo
+                           :directives [[:fooDirective {:arguments {:bar 123}}]]} [:bar]])
+; alt
+(oksa/gql (fragment (opts
+                      (name :foo)
+                      (on :Foo)
+                      (directive :fooDirective (argument :bar 123)))
+            (select :bar)))
 ;; => "fragment foo on Foo@fooDirective(bar:123){bar}"
 ```
 
 Fragment spreads:
 
 ```clojure
-(oksa/unparse [:foo [:oksa/fragment-spread {:name :bar}]])
-
-;; or
-
-(oksa/unparse [:foo [:... {:name :bar}]])
+(oksa/gql [:foo [:oksa/fragment-spread {:name :bar}]])
+(oksa/gql [:foo [:... {:name :bar}]])
+(oksa/gql (select :foo (fragment-spread (opts (name :bar)))))
 ;; => "{foo ...bar}"
 
 ;; with directives
-(oksa/unparse [[:... {:name :foo :directives [:bar]}]])
+(oksa/gql [[:... {:name :foo :directives [:bar]}]])
+(oksa/gql (select (fragment-spread (opts (name :foo) (directive :bar)))))
 ;; => "{...foo@bar}"
 
 ;; with arguments
-(oksa/unparse [[:... {:name :foo
-                      :directives [[:bar {:arguments {:qux 123}}]]}]])
+(oksa/gql [[:... {:name :foo :directives [[:bar {:arguments {:qux 123}}]]}]])
+(oksa/gql (select (fragment-spread (opts (name :foo) (directive :bar (arguments :qux 123))))))
 ;; => "{...foo@bar(qux:123)}"
 ```
 
 Inline fragments:
 
 ```clojure
-(oksa/unparse [:foo [:oksa/inline-fragment [:bar]]])
-
-;; or
-
-(oksa/unparse [:foo [:... [:bar]]])
+(oksa/gql [:foo [:oksa/inline-fragment [:bar]]])
+(oksa/gql [:foo [:... [:bar]]])
+(oksa/gql (select :foo (inline-fragment
+                         (select :bar))))
 ;; => "{foo ...{bar}}"
 
-(oksa/unparse [:foo [:... {:on :Bar} [:bar]]])
+(oksa/gql [:foo [:... {:on :Bar} [:bar]]])
+(oksa/gql (select :foo (inline-fragment (opts (on :Bar))
+                         (select :bar))))
 ;; => "{foo ...on Bar{bar}}"
 
 ;; with directives
-(oksa/unparse [[:... {:directives [:foo]} [:bar]]])
+(oksa/gql [[:... {:directives [:foo]} [:bar]]])
+(oksa/gql (select (inline-fragment (opts (directive :foo))
+                    (select :bar))))
 ;; => "{...@foo{bar}}"
 
 ;; with arguments
-(oksa/unparse [[:... {:directives [[:foo {:arguments {:bar 123}}]]}
-                [:foobar]]])
+(oksa/gql [[:... {:directives [[:foo {:arguments {:bar 123}}]]} [:foobar]]])
+(oksa/gql (select (inline-fragment (opts (directive :foo (argument :bar 123)))
+                    (select :foobar))))
 ;; => "{...@foo(bar:123){foobar}}"
 ```
 
@@ -312,15 +380,27 @@ Inline fragments:
 Putting it all together:
 
 ```clojure
-(oksa/unparse [:oksa/document
-               [:foo]
-               [:oksa/query [:bar]]
-               [:oksa/mutation [:qux]]
-               [:oksa/subscription [:baz]]
-               [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
+(oksa/gql [:oksa/document
+           [:foo]
+           [:oksa/query [:bar]]
+           [:oksa/mutation [:qux]]
+           [:oksa/subscription [:baz]]
+           [:oksa/fragment {:name :foo :on :Foo} [:bar]]])
 ;; => "{foo}\nquery {bar}\nmutation {qux}\nsubscription {baz}\nfragment foo on Foo{bar}"
 
-(oksa/unparse [:<> [:foo] [:bar]]) ; :<> also supported
+;; alt
+(oksa/gql
+  (document
+    (select :foo)
+    (query (select :bar))
+    (mutation (select :qux))
+    (subscription (select :baz))
+    (fragment (opts
+                (name :foo)
+                (on :Foo))
+      (select :bar))))
+
+(oksa/gql [:<> [:foo] [:bar]]) ; :<> also supported
 ;; => "{foo}\n{bar}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,43 @@ Oksa is currently [experimental](https://github.com/topics/metosin-experimental)
 (oksa/gql (select :hello (select :world)))
 ```
 
+More complete example using `oksa.alpha.api`:
+
+```clojure
+(oksa/gql
+  (document
+    (fragment (opts
+                (name :Kikka)
+                (on :Kukka))
+      (select :kikka :kukka))
+    (select :ylakikka
+      (select :kikka :kukka :kakku)
+      ;; v similar to ^, but allow to specify option for single field (only)
+      (field :kikka (opts
+                      (alias :KIKKA)
+                      (directives :kakku :kukka)
+                      (directive :kikkaized {:x 1 :y 2 :z 3})))
+      (when false (field :conditionalKikka)) ; nils are dropped
+      (fragment-spread (opts (name :FooFragment)))
+      (inline-fragment (opts (on :Kikka))
+        (select :kikka :kukka)))
+    (query (opts (name :KikkaQuery))
+      (select :specialKikka))
+    (mutation (opts
+                (name :saveKikka)
+                (variable :myKikka (opts (default 123)) :KikkaType))
+      (select :getKikka))
+    (subscription (opts (name :subscribeToKikka))
+      (select :realtimeKikka))))
+
+; =>
+; "fragment Kikka on Kukka{kikka kukka}
+;  {ylakikka{kikka kukka kakku} KIKKA:kikka@kakku @kukka @kikkaized(x:1, y:2, z:3) ...FooFragment ...on Kikka{kikka kukka}}
+;  query KikkaQuery {specialKikka}
+;  mutation saveKikka ($myKikka:KikkaType=123){getKikka}
+;  subscription subscribeToKikka {realtimeKikka}"
+```
+
 ### Operation definitions
 
 #### Selection sets

--- a/README.md
+++ b/README.md
@@ -37,43 +37,6 @@ Oksa is currently [experimental](https://github.com/topics/metosin-experimental)
 (oksa/gql (select :hello (select :world)))
 ```
 
-More complete example using `oksa.alpha.api`:
-
-```clojure
-(oksa/gql
-  (document
-    (fragment (opts
-                (name :Kikka)
-                (on :Kukka))
-      (select :kikka :kukka))
-    (select :ylakikka
-      (select :kikka :kukka :kakku)
-      ;; v similar to ^, but allow to specify option for single field (only)
-      (field :kikka (opts
-                      (alias :KIKKA)
-                      (directives :kakku :kukka)
-                      (directive :kikkaized {:x 1 :y 2 :z 3})))
-      (when false (field :conditionalKikka)) ; nils are dropped
-      (fragment-spread (opts (name :FooFragment)))
-      (inline-fragment (opts (on :Kikka))
-        (select :kikka :kukka)))
-    (query (opts (name :KikkaQuery))
-      (select :specialKikka))
-    (mutation (opts
-                (name :saveKikka)
-                (variable :myKikka (opts (default 123)) :KikkaType))
-      (select :getKikka))
-    (subscription (opts (name :subscribeToKikka))
-      (select :realtimeKikka))))
-
-; =>
-; "fragment Kikka on Kukka{kikka kukka}
-;  {ylakikka{kikka kukka kakku} KIKKA:kikka@kakku @kukka @kikkaized(x:1, y:2, z:3) ...FooFragment ...on Kikka{kikka kukka}}
-;  query KikkaQuery {specialKikka}
-;  mutation saveKikka ($myKikka:KikkaType=123){getKikka}
-;  subscription subscribeToKikka {realtimeKikka}"
-```
-
 ### Operation definitions
 
 #### Selection sets
@@ -439,6 +402,43 @@ Putting it all together:
 
 (oksa/gql [:<> [:foo] [:bar]]) ; :<> also supported
 ;; => "{foo}\n{bar}"
+```
+
+More complete example using `oksa.alpha.api`:
+
+```clojure
+(oksa/gql
+  (document
+    (fragment (opts
+                (name :Kikka)
+                (on :Kukka))
+      (select :kikka :kukka))
+    (select :ylakikka
+      (select :kikka :kukka :kakku)
+      ;; v similar to ^, but allow to specify option for single field (only)
+      (field :kikka (opts
+                      (alias :KIKKA)
+                      (directives :kakku :kukka)
+                      (directive :kikkaized {:x 1 :y 2 :z 3})))
+      (when false (field :conditionalKikka)) ; nils are dropped
+      (fragment-spread (opts (name :FooFragment)))
+      (inline-fragment (opts (on :Kikka))
+        (select :kikka :kukka)))
+    (query (opts (name :KikkaQuery))
+      (select :specialKikka))
+    (mutation (opts
+                (name :saveKikka)
+                (variable :myKikka (opts (default 123)) :KikkaType))
+      (select :getKikka))
+    (subscription (opts (name :subscribeToKikka))
+      (select :realtimeKikka))))
+
+; =>
+; "fragment Kikka on Kukka{kikka kukka}
+;  {ylakikka{kikka kukka kakku} KIKKA:kikka@kakku @kukka @kikkaized(x:1, y:2, z:3) ...FooFragment ...on Kikka{kikka kukka}}
+;  query KikkaQuery {specialKikka}
+;  mutation saveKikka ($myKikka:KikkaType=123){getKikka}
+;  subscription subscribeToKikka {realtimeKikka}"
 ```
 
 ## Rationale

--- a/src/oksa/alpha/api.cljc
+++ b/src/oksa/alpha/api.cljc
@@ -1,0 +1,1180 @@
+(ns oksa.alpha.api
+  (:require [oksa.parse]
+            [oksa.unparse]
+            [oksa.util]
+            [oksa.alpha.protocol :refer [Argumented
+                                         AST
+                                         Serializable
+                                         Representable
+                                         UpdateableOption]
+             :as protocol])
+  (:refer-clojure :exclude [assert name alias set list type]))
+
+#?(:cljs (goog-define mode "default")
+   :clj  (def ^{:doc "Modes `default` and `debug` supported."}
+           mode (as-> (or (System/getProperty "oksa.api/mode") "default") $ (.intern $))))
+
+(defn -query?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/query)))
+
+(defn -mutation?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/mutation)))
+
+(defn -subscription?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/subscription)))
+
+(defn -fragment?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/fragment)))
+
+(defn -field?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa.parse/Field)))
+
+(defn -naked-field?
+  [x]
+  (or (and (satisfies? AST x)
+           (= (protocol/-type x) :oksa.parse/NakedField))
+      (keyword? x)
+      (string? x)))
+
+(defn -directive-name? [x]
+  (or (and (satisfies? AST x)
+           (= (protocol/-type x) :oksa.parse/DirectiveName))
+      (keyword? x)
+      (string? x)))
+
+(defn -directive? [x]
+  (or (and (satisfies? AST x)
+           (= (protocol/-type x) :oksa.parse/Directive))
+      (keyword? x)
+      (string? x)))
+
+(defn -directives? [x]
+  (or (and (satisfies? AST x)
+           (= (protocol/-type x) :oksa.parse/Directives))
+      (keyword? x)
+      (string? x)))
+
+(defn -selection-set?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa.parse/SelectionSet)))
+
+(defn -fragment-spread?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/fragment-spread)))
+
+(defn -inline-fragment?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa/inline-fragment)))
+
+(defn -type?
+  [x]
+  (or (and (satisfies? AST x)
+        (or (= (protocol/-type x) :oksa.parse/TypeName)
+            (= (protocol/-type x) :oksa.parse/NamedTypeOrNonNullNamedType)))
+      (keyword? x)
+      (string? x)))
+
+(defn -list?
+  [x]
+  (and (satisfies? AST x)
+       (= (protocol/-type x) :oksa.parse/ListTypeOrNonNullListType)))
+
+(defn -validate
+  ([x msg]
+   (-validate x msg {}))
+  ([x msg data]
+   (when (not x)
+     (throw (ex-info msg data)))))
+
+(defn -parse-or-throw
+  [type form parser message]
+  (let [retval (parser form)]
+    (if (not= retval :malli.core/invalid)
+      retval
+      (throw (ex-info message
+                      (cond
+                        (= mode "debug") {:malli.core/explain (malli.core/explain
+                                                               (oksa.parse/-graphql-dsl-lang type)
+                                                               form)}
+                        (= mode "default") {}
+                        :else (throw (ex-info "incorrect `oksa.api/mode` (system property), expected one of `default` or `debug`" {:mode mode}))))))))
+
+(defn document
+  "Composes many executable definitions together to produce a single document.
+
+  `definitions` can be many of:
+  - `oksa.alpha.api/query`
+  - `oksa.alpha.api/mutation`
+  - `oksa.alpha.api/subscription`
+  - `oksa.alpha.api/fragment`
+  - `oksa.alpha.api/select`
+
+  Tolerates nil entries.
+
+  Example:
+
+  ```
+  (document
+    (select :foo)
+    (query (select :bar))
+    (mutation (select :qux))
+    (subscription (select :baz))
+    (fragment (opts
+                (name :foo)
+                (on :Foo))
+      (select :bar)))
+  ```
+
+  See also [Document](https://spec.graphql.org/October2021/#Document)."
+  [& definitions]
+  (let [definitions* (filter some? definitions)]
+    (-validate (and (not-empty definitions*)
+                    (every? #(or (-query? %)
+                                 (-mutation? %)
+                                 (-subscription? %)
+                                 (-selection-set? %)
+                                 (-fragment? %)) definitions*))
+               "invalid definitions, expected `oksa.alpha.api/query`, `oksa.alpha.api/mutation`, `oksa.alpha.api/subscription`, `oksa.alpha.api/fragment`, or `oksa.alpha.api/select`")
+    (let [form (into [:oksa/document {}] (map protocol/-form definitions*))
+          [type opts _definitions :as document*] (-parse-or-throw :oksa.parse/Document
+                                                                  form
+                                                                  oksa.parse/-graphql-dsl-parser
+                                                                  "invalid document")]
+      (reify
+        AST
+        (-type [_] type)
+        (-opts [_] opts)
+        (-parsed-form [_] document*)
+        (-form [_] form)
+        Serializable
+        (-unparse [_]
+          (oksa.unparse/unparse-document definitions*))
+        Representable
+        (-gql [this] (protocol/-unparse this))))))
+
+(defn -operation-definition
+  [operation-type opts selection-set]
+  (let [opts (or opts {})
+        form [operation-type opts (protocol/-form selection-set)]
+        [type opts _selection-set :as parsed-form] (-parse-or-throw :oksa.parse/OperationDefinition
+                                                                    form
+                                                                    oksa.parse/-operation-definition-parser
+                                                                    "invalid operation definition")]
+    (reify
+      AST
+      (-type [_] type)
+      (-opts [_] (-> opts
+                     (update :directives (partial oksa.util/transform-malli-ast oksa.parse/-transform-map))
+                     (update :variables (partial oksa.util/transform-malli-ast oksa.parse/-transform-map))))
+      (-parsed-form [_] parsed-form)
+      (-form [_] form)
+      Serializable
+      (-unparse [this]
+        (oksa.unparse/unparse-operation-definition
+         (clojure.core/name (protocol/-type this))
+         (protocol/-opts this)
+         selection-set))
+      Representable
+      (-gql [this] (protocol/-unparse this)))))
+
+(defn query
+  "Produces an operation definition of `query` operation type using the fields defined in `selection-set`. Supports query naming, variable definitions, and directives through `opts`.
+
+  Expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is an (optional) map and uses the following fields here:
+
+  | field         | description                                                                                                           | API reference                                             |
+  |---------------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:name`       | A query name conforming to [Name](https://spec.graphql.org/October2021/#Name)                                         | `oksa.alpha.api/name`                                     |
+  | `:variables`  | Query variable definitions, see also [VariableDefinitions](https://spec.graphql.org/October2021/#VariableDefinitions) | `oksa.alpha.api/variables` or `oksa.alpha.api/variable`   |
+  | `:directives` | Query directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)                             | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (query (select :foo :bar)))
+  ; => query {foo bar}
+
+  (gql
+   (query (opts (name :Foobar)
+                (variables :foo :FooType
+                           :bar :BarType)
+                (directives :fooDirective :barDirective))
+     (select :foo :bar)))
+  ; => query Foobar ($foo:FooType,$bar:BarType)@fooDirective @barDirective{foo bar}
+  ```
+
+  See also [OperationDefinition](https://spec.graphql.org/October2021/#OperationDefinition)."
+  ([selection-set]
+   (query nil selection-set))
+  ([opts selection-set]
+   (-validate (or (and (nil? opts) (-selection-set? selection-set))
+                  (and (map? opts) (-selection-set? selection-set))) "expected either `oksa.alpha.api/opts` & `oksa.alpha.api/select`, or `oksa.alpha.api/select`")
+   (-operation-definition :oksa/query opts selection-set)))
+
+(defn mutation
+  "Produces an operation definition of `mutation` operation type using the fields defined in `selection-set`.
+
+  Supports query naming, variable definitions, and directives through `opts`, and expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is an (optional) map and uses the following fields here:
+
+  | field         | description                                                                                                              | API reference                                             |
+  |---------------|--------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:name`       | Mutation name conforming to [Name](https://spec.graphql.org/October2021/#Name)                                           | `oksa.alpha.api/name`                                     |
+  | `:variables`  | Mutation variable definitions, see also [VariableDefinitions](https://spec.graphql.org/October2021/#VariableDefinitions) | `oksa.alpha.api/variables` or `oksa.alpha.api/variable`   |
+  | `:directives` | Mutation directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)                             | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (mutation (select :foo :bar)))
+  ; => mutation {foo bar}
+
+  (gql
+   (mutation (opts (name :Foobar)
+                   (variables :foo :FooType
+                              :bar :BarType)
+                   (directives :fooDirective :barDirective))
+             (select :foo :bar)))
+  ; => mutation Foobar ($foo:FooType,$bar:BarType)@fooDirective @barDirective{foo bar}
+  ```
+
+  See also [OperationDefinition](https://spec.graphql.org/October2021/#OperationDefinition)."
+  ([selection-set]
+   (mutation nil selection-set))
+  ([opts selection-set]
+   (-validate (or (and (nil? opts) (-selection-set? selection-set))
+                  (and (map? opts) (-selection-set? selection-set))) "expected either `oksa.alpha.api/opts` & `oksa.alpha.api/select`, or `oksa.alpha.api/select`")
+   (-operation-definition :oksa/mutation opts selection-set)))
+
+(defn subscription
+  "Produces an operation definition of `subscription` operation type using the fields defined in `selection-set`.
+
+  Supports query naming, variable definitions, and directives through `opts`, and expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is an (optional) map and uses the following fields here:
+
+  | field         | description                                                                                                                  | API reference                                             |
+  |---------------|------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:name`       | A subscription name conforming to [Name](https://spec.graphql.org/October2021/#Name)                                         | `oksa.alpha.api/name`                                     |
+  | `:variables`  | Subscription variable definitions, see also [VariableDefinitions](https://spec.graphql.org/October2021/#VariableDefinitions) | `oksa.alpha.api/variables` or `oksa.alpha.api/variable`   |
+  | `:directives` | Subscription directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)                             | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (subscription (select :foo :bar)))
+  ; => subscription {foo bar}
+
+  (gql
+   (subscription (opts (name :Foobar)
+                       (variables :foo :FooType
+                                  :bar :BarType)
+                       (directives :fooDirective :barDirective))
+                 (select :foo :bar)))
+  ; => subscription Foobar ($foo:FooType,$bar:BarType)@fooDirective @barDirective{foo bar}
+  ```
+
+  See also [OperationDefinition](https://spec.graphql.org/October2021/#OperationDefinition)."
+  ([selection-set]
+   (subscription nil selection-set))
+  ([opts selection-set]
+   (-validate (or (and (nil? opts) (-selection-set? selection-set))
+                  (and (map? opts) (-selection-set? selection-set))) "expected either `oksa.alpha.api/opts` & `oksa.alpha.api/select`, or `oksa.alpha.api/select`")
+   (-operation-definition :oksa/subscription opts selection-set)))
+
+(defn fragment
+  "Produces a fragment definition using the fields defined in `selection-set`.
+
+  Expects `:name` and `:on` fields under `opts` arg, and expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is a map and uses the following fields here:
+
+  | field         | required | description                                                                                   | API reference                                             |
+  |---------------|----------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:name`       | true     | A fragment name conforming to [Name](https://spec.graphql.org/October2021/#Name)              | `oksa.alpha.api/name`                                     |
+  | `:on`         | true     | Type condition, see also [TypeCondition](https://spec.graphql.org/October2021/#TypeCondition) | `oksa.alpha.api/on`                                       |
+  | `:directives` | false    | Fragment directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)  | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (fragment (opts (name :FooFragment)
+                   (on :FooType))
+     (select :foo :bar)))
+  ; => fragment FooFragment on FooType{foo bar}
+
+  (gql
+   (fragment (opts (name :FooFragment)
+                   (on :FooType)
+                   (directives :fooDirective :barDirective))
+     (select :foo :bar)))
+  ; => fragment FooFragment on FooType@fooDirective @barDirective{foo bar}
+  ```
+
+  See also [FragmentDefinition](https://spec.graphql.org/October2021/#FragmentDefinition)."
+  [opts selection-set]
+  (-validate (:name opts) "expected `oksa.alpha.api/name` on `opts`")
+  (-validate (:on opts) "expected `oksa.alpha.api/on` on `opts`")
+  (let [form [:oksa/fragment opts (protocol/-form selection-set)]
+        [type opts _selection-set
+         :as fragment*] (-parse-or-throw :oksa.parse/FragmentDefinition
+                                         form
+                                         oksa.parse/-fragment-definition-parser
+                                         "invalid fragment definition")]
+    (reify
+      AST
+      (-type [_] type)
+      (-opts [_] (update opts :directives (partial oksa.util/transform-malli-ast oksa.parse/-transform-map)))
+      (-parsed-form [_] fragment*)
+      (-form [_] form)
+      Serializable
+      (-unparse [this] (oksa.unparse/unparse-fragment-definition (protocol/-opts this) selection-set))
+      Representable
+      (-gql [this] (protocol/-unparse this)))))
+
+(declare -naked-field)
+
+(defn select
+  "Produces a selection set using `selections`.
+
+  Expects an entry in `selections` to be an instance of:
+  - `oksa.alpha.api/field`
+  - keyword (representing a naked field)
+  - `oksa.alpha.api/fragment-spread`
+  - `oksa.alpha.api/inline-fragment`
+
+  Tolerates nil entries.
+
+  Examples:
+
+  ```
+  (gql
+   (select :foo :bar))
+  ; => {foo bar}
+
+  (gql
+   (select :foo :bar
+     (select :qux :baz)
+     (field :foobar (opts (alias :BAR)))
+     (when false (field :conditionalFoo))
+     (fragment-spread (opts (name :FooFragment)))
+     (inline-fragment (opts (on :KikkaType))
+       (select :kikka :kukka))))
+  ; => {foo bar{qux baz} BAR:foobar ...FooFragment ...on KikkaType{kikka kukka}}
+  ```
+
+  See also [SelectionSet](https://spec.graphql.org/October2021/#SelectionSet).
+  "
+  [& selections]
+  (let [selections* (->> selections (filter some?) (map (fn [selection]
+                                                          (if (-naked-field? selection)
+                                                            (-naked-field selection)
+                                                            selection))))]
+    (-validate (not (-selection-set? (first selections*))) "first selection cannot be `oksa.alpha.api/select`")
+    (-validate (and (not-empty selections*)
+                    (every? #(or (-field? %)
+                                 (-naked-field? %)
+                                 (-selection-set? %)
+                                 (-fragment-spread? %)
+                                 (-inline-fragment? %)) selections*))
+               "invalid selections, expected `oksa.alpha.api/field`, keyword (naked field), `oksa.alpha.api/fragment-spread`, or `oksa.alpha.api/inline-fragment`")
+    (let [form (mapv #(if (satisfies? AST %) (protocol/-form %) %) selections*)
+          [type _selections
+           :as parsed-form] (-parse-or-throw :oksa.parse/SelectionSet
+                                             form
+                                             oksa.parse/-selection-set-parser
+                                             "invalid selection-set")]
+      (reify
+        AST
+        (-type [_] type)
+        (-opts [_] {})
+        (-parsed-form [_] parsed-form)
+        (-form [_] form)
+        Serializable
+        (-unparse [_] (oksa.unparse/unparse-selection-set selections*))
+        Representable
+        (-gql [this] (protocol/-unparse this))))))
+
+(defn field
+  "Produces a field using `name`. Can be used directly within `oksa.alpha.api/select` when you need to provide options (eg. arguments, directives) for a particular field.
+
+  Multiple arities are supported:
+  - `(field name)`
+  - `(field name opts)`
+  - `(field name selection-set)`
+  - `(field name opts selection-set)`
+
+  Expects `name` to conform to [Name](https://spec.graphql.org/October2021/#Name), and expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is an (optional) map and uses the following fields here:
+
+  | field         | description                                                                               | API reference                                             |
+  |---------------|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:alias`      | A field alias conforming to [Alias](https://spec.graphql.org/October2021/#Alias)          | `oksa.alpha.api/alias`                                    |
+  | `:arguments`  | Field arguments, see also [Arguments](https://spec.graphql.org/October2021/#Arguments)    | `oksa.alpha.api/arguments` or `oksa.alpha.api/argument`   |
+  | `:directives` | Field directives, see also [Directives](https://spec.graphql.org/October2021/#Directives) | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (select
+     (field :foo)
+     (field :bar)))
+  ; => {foo bar}
+
+  (gql
+   (select
+     (field :foo (opts (alias :FOO)))))
+  ; => {FOO:foo}
+
+  (gql
+   (select
+     (field :foo (select :bar))))
+  ; => {foo{bar}}
+
+  (gql
+   (select
+     (field :foo (opts (alias :FOO)
+                       (directives :fooDirective :barDirective)
+                       (arguments :fooArg \"fooValue\"
+                                  :barArg 123))
+       (select :bar))))
+  ; => {FOO:foo(fooArg:\"fooValue\", barArg:123)@fooDirective @barDirective{bar}}
+  ```
+
+  See tests for more examples.
+
+  See also [Field](https://spec.graphql.org/October2021/#Field)."
+  ([name]
+   (field name nil nil))
+  ([name selection-set-or-opts]
+   (-validate (or (-selection-set? selection-set-or-opts)
+                  (map? selection-set-or-opts)
+                  (nil? selection-set-or-opts)) "expected either `oksa.alpha.api/opts` or `oksa.alpha.api/select`")
+   (cond
+     (-selection-set? selection-set-or-opts) (field name nil selection-set-or-opts)
+     (map? selection-set-or-opts) (field name selection-set-or-opts nil)
+     (nil? selection-set-or-opts) (field name nil nil)))
+  ([name opts selection-set]
+   (when (some? opts)
+     (-validate (map? opts) "expected `oksa.alpha.api/opts`"))
+   (when (some? selection-set)
+     (-validate (-selection-set? selection-set) "expected `oksa.alpha.api/select`"))
+   (let [opts (or opts {})
+         form (cond-> [name opts]
+                (some? selection-set) (conj (protocol/-form selection-set)))
+         [type [_field-name field-opts _selection-set*]
+          :as field*] (-parse-or-throw :oksa.parse/Field
+                                       form
+                                       oksa.parse/-field-parser
+                                       "invalid field")]
+     (reify
+       AST
+       (-type [_] type)
+       (-opts [_] (update field-opts
+                          :directives
+                          (partial oksa.util/transform-malli-ast oksa.parse/-transform-map)))
+       (-parsed-form [_] field*)
+       (-form [_] form)
+       Serializable
+       (-unparse [this] (oksa.unparse/unparse-field name (protocol/-opts this) selection-set))))))
+
+(defn -naked-field
+  [name]
+  (let [naked-field* (-parse-or-throw :oksa.parse/NakedField
+                                      name
+                                      oksa.parse/-naked-field-parser
+                                      "invalid naked field")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/NakedField)
+      (-opts [_] {})
+      (-parsed-form [_] naked-field*)
+      (-form [_] naked-field*)
+      Serializable
+      (-unparse [_] (clojure.core/name naked-field*)))))
+
+(defn fragment-spread
+  "Produces a fragment spread using `:name` under `opts`. Can be used directly within `oksa.alpha.api/select`.
+
+  Expects `:name` under `opts` arg.
+
+  `opts` is a map and uses the following fields here:
+
+  | field         | required | description                                                                                   | API reference                                             |
+  |---------------|----------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:name`       | true     | A fragment name conforming to [Name](https://spec.graphql.org/October2021/#Name)              | `oksa.alpha.api/name`                                     |
+  | `:directives` | false    | Fragment directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)  | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (select (fragment-spread (opts (name :Foo)))))
+  ; => {...Foo}
+
+  (gql
+    (select
+      (fragment-spread (opts
+                         (name :Foo)
+                         (directives :fooDirective :barDirective)))))
+  ; => {...Foo@fooDirective @barDirective}
+  ```
+
+  See also [FragmentSpread](https://spec.graphql.org/October2021/#FragmentSpread)."
+  [opts]
+  (-validate (some? (:name opts)) "expected `oksa.alpha.api/name` for `opts`")
+  (let [form [:oksa/fragment-spread opts]
+        [type opts :as fragment-spread*] (-parse-or-throw :oksa.parse/FragmentSpread
+                                                          form
+                                                          oksa.parse/-fragment-spread-parser
+                                                          "invalid fragment spread parser")]
+    (reify
+      AST
+      (-type [_] type)
+      (-opts [_] (update opts
+                         :directives
+                         (partial oksa.util/transform-malli-ast
+                                  oksa.parse/-transform-map)))
+      (-parsed-form [_] fragment-spread*)
+      (-form [_] form)
+      Serializable
+      (-unparse [this] (oksa.unparse/unparse-fragment-spread (protocol/-opts this))))))
+
+(defn inline-fragment
+  "Produces an inline fragment using the fields defined in `selection-set`. Can be used directly within `oksa.alpha.api/select`.
+
+  Expects `selection-set` to be an instance of `oksa.alpha.api/select`.
+
+  `opts` is an (optional) map and uses the following fields here:
+
+  | field         | description                                                                                   | API reference                                             |
+  |---------------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:on`         | Type condition, see also [TypeCondition](https://spec.graphql.org/October2021/#TypeCondition) | `oksa.alpha.api/on`                                       |
+  | `:directives` | Fragment directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)  | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (gql
+   (select
+     (inline-fragment (select :foo :bar))))
+  ; => {...{foo}}
+
+  (gql
+   (select
+     (inline-fragment (opts (on :FooType)
+                            (directives :fooDirective :barDirectives))
+       (select :foo :bar))))
+  ; => {...on FooType@fooDirective @barDirectives{foo bar}}
+  ```
+
+  See also [InlineFragment](https://spec.graphql.org/October2021/#InlineFragment)."
+  ([selection-set]
+   (inline-fragment nil selection-set))
+  ([opts selection-set]
+   (-validate (or (and (nil? opts) (-selection-set? selection-set))
+                  (and (map? opts) (-selection-set? selection-set))) "expected either `oksa.alpha.api/opts`, `oksa.alpha.api/select` or `oksa.alpha.api/opts` & `oksa.alpha.api/select` as vargs")
+   (let [opts (or opts {})
+         form (cond-> [:oksa/inline-fragment opts] (some? selection-set) (conj (protocol/-form selection-set)))
+         [type opts :as inline-fragment*] (-parse-or-throw :oksa.parse/InlineFragment
+                                                           form
+                                                           oksa.parse/-inline-fragment-parser
+                                                           "invalid inline fragment parser")]
+     (reify
+       AST
+       (-type [_] type)
+       (-opts [_] (update opts
+                          :directives
+                          (partial oksa.util/transform-malli-ast
+                                   oksa.parse/-transform-map)))
+       (-parsed-form [_] inline-fragment*)
+       (-form [_] form)
+       Serializable
+       (-unparse [this] (oksa.unparse/unparse-inline-fragment (protocol/-opts this) selection-set))))))
+
+(defn opts
+  "Produces a map of `options`, a collection of `oksa.alpha.protocol/UpdateableOption`s. Output is a `clojure.lang.IPersistentMap`.
+
+  Tolerates nil entries.
+
+  Each instance of `oksa.alpha.protocol/UpdateableOption` implements their own behavior on where & how to update `opts` with the instance's own value:
+
+  |  API reference              | Key           | Expected update behavior |
+  |-----------------------------|---------------|--------------------------|
+  | `oksa.alpha.api/alias`      | `:alias`      | Replaces value           |
+  | `oksa.alpha.api/argument`   | `:arguments`  | Associates value         |
+  | `oksa.alpha.api/arguments`  | `:arguments`  | Associates value(s)      |
+  | `oksa.alpha.api/default`    | `:default`    | Replaces value           |
+  | `oksa.alpha.api/directive`  | `:directive`  | Appends value            |
+  | `oksa.alpha.api/directives` | `:directives` | Appends value(s)         |
+  | `oksa.alpha.api/name`       | `:name`       | Replaces value           |
+  | `oksa.alpha.api/on`         | `:on`         | Replaces value           |
+  | `oksa.alpha.api/variable`   | `:variables`  | Appends value            |
+  | `oksa.alpha.api/variables`  | `:variables`  | Appends value(s)         |
+
+  Examples:
+
+  ```
+  (opts (alias :bar))
+  ; => {:alias :bar}
+
+  (opts
+   (name :foo)
+   (on :Foo)
+   (directives :fooDirective :barDirective))
+  ; => {:name :foo, :on :Foo, :directives [:fooDirective :barDirective]}
+  ```
+
+  See tests for more examples."
+  [& options]
+  (let [vargs* (filter some? options)]
+    (-validate (every? #(satisfies? UpdateableOption %) vargs*)
+               (str "invalid option, expected: "
+                    "`oksa.alpha.api/on`, `oksa.alpha.api/name`, `oksa.alpha.api/alias`, "
+                    "`oksa.alpha.api/directive`, `oksa.alpha.api/directives`, `oksa.alpha.api/argument`, "
+                    "`oksa.alpha.api/arguments`, `oksa.alpha.api/variable`, "
+                    "`oksa.alpha.api/variables`, or `oksa.alpha.api/default`"))
+    (reduce (fn [m itm]
+              (cond
+                (satisfies? UpdateableOption itm) (update m (protocol/-update-key itm) (protocol/-update-fn itm))
+                :else m))
+            {}
+            vargs*)))
+
+(defn on
+  "Returns a type condition under key `:on` using `name` which should conform to [NamedType](https://spec.graphql.org/October2021/#NamedType). Used directly within `oksa.alpha.api/opts`.
+
+  Example:
+
+  ```
+  (opts
+   (name :foo)
+   (on :Foo))
+  ; => {:name :foo, :on :Foo}
+  ```
+
+  See also [TypeCondition](https://spec.graphql.org/October2021/#TypeCondition)."
+  [name]
+  (let [form name
+        name* (-parse-or-throw :oksa.parse/Name
+                               name
+                               oksa.parse/-name-parser
+                               "invalid `on`")]
+    (reify
+      AST
+      (-form [_] form)
+      (-parsed-form [_] name*)
+      (-type [_] :oksa.parse/Name)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :on)
+      (-update-fn [this] (constantly (protocol/-form this))))))
+
+(defn name
+  "Returns `name` under key `:name`. Name should conform to [Name](https://spec.graphql.org/October2021/#Name). Used directly within `oksa.alpha.api/opts`.
+
+  Example:
+
+  ```
+  (opts
+   (name :foo)
+   (on :Foo))
+  ; => {:name :foo, :on :Foo}
+  ```
+
+  See [Name](https://spec.graphql.org/October2021/#Name)."
+  [name]
+  (let [form name
+        name* (-parse-or-throw :oksa.parse/Name
+                               name
+                               oksa.parse/-name-parser
+                               "invalid name")]
+    (reify
+      AST
+      (-form [_] form)
+      (-parsed-form [_] name*)
+      (-type [_] :oksa.parse/Name)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :name)
+      (-update-fn [this] (constantly (protocol/-form this))))))
+
+(defn alias
+  "Returns an alias under key `:alias` using `name` which should conform to [Name](https://spec.graphql.org/October2021/#Name). Used directly within `oksa.alpha.api/opts`.
+
+  Example:
+
+  ```
+  (opts
+   (alias :foo))
+  ; => {:alias :foo}
+  ```
+
+  See also [Alias](https://spec.graphql.org/October2021/#Alias)."
+  [name]
+  (let [form name
+        alias* (-parse-or-throw :oksa.parse/Alias
+                                form
+                                oksa.parse/-alias-parser
+                                "invalid alias")]
+    (reify
+      AST
+      (-form [_] form)
+      (-parsed-form [_] alias*)
+      (-type [_] :oksa.parse/Alias)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :alias)
+      (-update-fn [this] (constantly (protocol/-form this))))))
+
+(defn -directive-name
+  [directive-name]
+  (let [directive-name* (-parse-or-throw :oksa.parse/DirectiveName
+                                         directive-name
+                                         oksa.parse/-directive-name-parser
+                                         "invalid directive name")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/DirectiveName)
+      (-opts [_] {})
+      (-parsed-form [_] directive-name*)
+      (-form [_] directive-name)
+      Serializable
+      (-unparse [_] (clojure.core/name directive-name*)))))
+
+(def -directives-empty-state [])
+(def -arguments-empty-state {})
+(def -variables-empty-state [])
+
+(defn directive
+  "Returns a directive under key `:directives` using `name` which should conform to [Name](https://spec.graphql.org/October2021/#Name). Used directly within `oksa.alpha.api/opts`.
+
+  Optionally accepts `arguments`, which is an instance of `oksa.alpha.api/Argumented` (ie. `oksa.alpha.api/argument` or `oksa.alpha.api/arguments`).
+
+  Examples:
+
+  ```
+  (opts
+   (directive :foo))
+  ; => {:directives [[:foo {}]]}
+
+  (opts
+   (directive :foo (arguments :bar 123)))
+  ; => {:directives [[:foo {:arguments {:bar 123}}]]}
+  ```
+
+  See also [Directive](https://spec.graphql.org/October2021/#Directive)."
+  ([name]
+   (directive name nil))
+  ([name arguments]
+   (let [opts (if (satisfies? protocol/Argumented arguments)
+                {:arguments (protocol/-arguments arguments)}
+                (cond-> {} (some? arguments) (assoc :arguments arguments)))
+         form [name opts]
+         directive* (-parse-or-throw :oksa.parse/Directive
+                                     form
+                                     oksa.parse/-directive-parser
+                                     "invalid directive")]
+     (reify
+       AST
+       (-form [_] form)
+       (-parsed-form [_] directive*)
+       (-type [_] :oksa.parse/Directive)
+       (-opts [_] opts)
+       UpdateableOption
+       (-update-key [_] :directives)
+       (-update-fn [this] #((fnil conj -directives-empty-state) % (protocol/-form this)))))))
+
+(defn directives
+  "Returns `directives` under key `:directives`. Used directly within `oksa.alpha.api/opts`.
+
+  Expects `directives` is a varargs consisting of keywords (naked directives) or instances of `oksa.alpha.api/directive`.
+
+  Tolerates nil entries.
+
+  Examples:
+
+  ```
+  (opts
+   (directives :foo :bar))
+  ; => {:directives [:foo :bar]}
+
+  (opts
+   (directive :foo)
+   (directive :bar)
+   (directives :frob :nitz))
+  ; => {:directives [[:foo {}] [:bar {}] :frob :nitz]}
+
+  ;; mixed use example
+  (opts
+   (directives
+    :foo
+    (directive :bar)
+    :foobar))
+  ; => {:directives [:foo [:bar {}] :foobar]}
+  ```
+
+  See also [Directives](https://spec.graphql.org/October2021/#Directives)."
+  [& directives]
+  (let [directives* (->> directives (filter some?) (map (fn [x]
+                                                          (if (-directive-name? x)
+                                                            (-directive-name x)
+                                                            x))))]
+    (-validate (and (not-empty directives*)
+                    (every? #(or (-directive-name? %)
+                                 (-directive? %)) directives*))
+               "invalid directives, expected `oksa.alpha.api/directive` or naked directive (keyword)")
+    (let [form (mapv protocol/-form directives*)
+          [type _directives
+           :as directives*] (-parse-or-throw :oksa.parse/Directives
+                                             form
+                                             oksa.parse/-directives-parser
+                                             "invalid directives")]
+      (reify
+        AST
+        (-type [_] type)
+        (-form [_] form)
+        (-parsed-form [_] directives*)
+        (-opts [_] {})
+        UpdateableOption
+        (-update-key [_] :directives)
+        (-update-fn [this] #((fnil into -directives-empty-state) % (protocol/-form this)))))))
+
+(defn argument
+  "Returns an argument under key `:arguments`. Used directly within `oksa.alpha.api/opts`.
+
+  Expects that `name` is a string or a keyword (that conforms to [Name](https://spec.graphql.org/October2021/#Name)) and that `value` conforms to [Value](https://spec.graphql.org/October2021/#Value).
+
+  Can also be used directly within `oksa.alpha.api/directive`.
+
+  Examples:
+
+  ```
+  (opts (argument :foo 1))
+  ; => {:arguments {:foo 1}}
+
+  (api/opts (api/directive :foo (api/argument :bar 123)))
+  ; => {:directives [[:foo {:arguments {:bar 123}}]]}
+  ```
+
+  See also [Argument](https://spec.graphql.org/October2021/#Argument)."
+  [name value]
+  (let [form {name value}
+        argument* (-parse-or-throw :oksa.parse/Arguments
+                                   form
+                                   oksa.parse/-arguments-parser
+                                   "invalid argument")]
+    (reify
+      AST
+      (-form [_] form)
+      (-parsed-form [_] argument*)
+      (-type [_] :oksa.parse/Arguments)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :arguments)
+      (-update-fn [this] #(merge % (protocol/-form this)))
+      Argumented
+      (-arguments [this] (protocol/-form this)))))
+
+(defn arguments
+  "Returns `arguments` under key `:arguments`. Used directly within `oksa.alpha.api/opts`.
+
+  Expects `arguments` to be pair(s) of names and values where name is a string or a keyword (that conforms to [Name](https://spec.graphql.org/October2021/#Name)) and where value conforms to [Value](https://spec.graphql.org/October2021/#Value).
+
+  Can also be used directly within `oksa.alpha.api/directive`.
+
+  Example:
+
+  ```
+  (opts (arguments :foo 1 :bar \"foobar\"))
+  ; => {:arguments {:foo 1, :bar \"foobar\"}}
+
+  (opts (directive :foo (arguments :qux 123 :baz \"frob\")))
+  ; => {:directives [[:foo {:arguments {:qux 123, :baz \"frob\"}}]]}
+  ```
+
+  See also [Arguments](https://spec.graphql.org/October2021/#Arguments)."
+  [& arguments]
+  (-validate (= (mod (count arguments) 2) 0) "uneven amount of arguments, expected key-value pairs")
+  (let [form (->> arguments
+                  (partition 2)
+                  (map vec)
+                  (into {}))
+        arguments* (-parse-or-throw :oksa.parse/Arguments
+                                    form
+                                    oksa.parse/-arguments-parser
+                                    "invalid arguments")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/Arguments)
+      (-form [_] form)
+      (-parsed-form [_] arguments*)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :arguments)
+      (-update-fn [this] #(merge % (protocol/-form this)))
+      Argumented
+      (-arguments [this] (protocol/-form this)))))
+
+(defn type
+  "Returns a named type using `type-name`.
+
+  See also [NamedType](https://spec.graphql.org/October2021/#NamedType)."
+  [type-name]
+  (let [form type-name
+        type* (-parse-or-throw :oksa.parse/TypeName
+                               form
+                               oksa.parse/-type-name-parser
+                               "invalid type")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/TypeName)
+      (-form [_] form)
+      (-parsed-form [_] type*)
+      (-opts [_] {})
+      Serializable
+      (-unparse [this] (clojure.core/name (protocol/-parsed-form this))))))
+
+(defn type!
+  "Returns a non-nil named type using `type-name`.
+
+  See also [NonNullType](https://spec.graphql.org/October2021/#NonNullType)."
+  [type-name]
+  (let [form [type-name {:non-null true}]
+        [type-name* _opts :as non-null-type*] (-parse-or-throw :oksa.parse/NamedTypeOrNonNullNamedType
+                                                               form
+                                                               oksa.parse/-named-type-or-non-null-named-type-parser
+                                                               "invalid non-null type")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/NamedTypeOrNonNullNamedType)
+      (-form [_] form)
+      (-parsed-form [_] non-null-type*)
+      (-opts [_] {})
+      Serializable
+      (-unparse [_] (str (clojure.core/name type-name*) "!")))))
+
+(defn -list
+  [opts type-or-list]
+  (-validate (or (-type? type-or-list) (-list? type-or-list))
+             "invalid type given, expected `oksa.alpha.api/type`, `oksa.alpha.api/type!`, keyword (naked type), `oksa.alpha.api/list`, or `oksa.alpha.api/list!`")
+  (let [type-or-list* (if (or (keyword? type-or-list) (string? type-or-list))
+                        (type type-or-list)
+                        type-or-list)
+        form [:oksa/list opts (protocol/-form type-or-list*)]
+        list* (-parse-or-throw :oksa.parse/ListTypeOrNonNullListType
+                               form
+                               oksa.parse/-list-type-or-non-null-list-type-parser
+                               "invalid list")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/ListTypeOrNonNullListType)
+      (-form [_] form)
+      (-parsed-form [_] list*)
+      (-opts [_] opts)
+      Serializable
+      (-unparse [this]
+        (oksa.unparse/-format-list type-or-list* (protocol/-opts this))))))
+
+(defn list
+  "Returns a list type using `type-or-list`.
+
+  Expects `type-or-list` to be an instance of `oksa.alpha.api/type`, `oksa.alpha.api/type!`, `oksa.alpha.api/list`, or `oksa.alpha.api/type!`.
+
+  Examples:
+
+  ```
+  (opts (variable :foo (list :FooType)))
+  ; => {:variables [:foo [:oksa/list {:non-null false} :FooType]]}
+
+  (opts (variable :foo (list (list :BarType))))
+  ; => {:variables [:foo
+  ;                 [:oksa/list
+  ;                  {:non-null false}
+  ;                  [:oksa/list {:non-null false} :BarType]]]}
+  ```
+
+  See also [ListType](https://spec.graphql.org/October2021/#ListType)."
+  [type-or-list]
+  (-list {:non-null false} type-or-list))
+
+(defn list!
+  "Returns a non-nil list type using `type-or-list`.
+
+  Expects `type-or-list` to be an instance of `oksa.alpha.api/type`, `oksa.alpha.api/type!`, `oksa.alpha.api/list`, or `oksa.alpha.api/type!`.
+
+  Examples:
+
+  ```
+  (opts (variable :foo (list! :FooType)))
+  ; => {:variables [:foo [:oksa/list {:non-null true} :FooType]]}
+
+  (opts (variable :foo (list (list! :BarType))))
+  ; => {:variables [:foo
+                    [:oksa/list
+                     {:non-null false}
+                     [:oksa/list {:non-null true} :BarType]]]}
+
+  (opts (variable :foo (list! (list! :BarType))))
+  ; => {:variables [:foo
+                    [:oksa/list
+                     {:non-null true}
+                     [:oksa/list {:non-null true} :BarType]]]}
+  ```
+
+  See also [NonNullType](https://spec.graphql.org/October2021/#NonNullType)."
+  [type-or-list]
+  (-list {:non-null true} type-or-list))
+
+(defn variable
+  "Returns a variable definition under `:variables` key using `variable-name` (which can be a string or a keyword) and `variable-type`. Used directly within `oksa.alpha.api/opts`.
+
+  `opts` is an (optional) map and uses the following field(s) here:
+
+  | field         | description                                                                                              | API reference                                             |
+  |---------------|----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+  | `:default`    | Default value for variable, see also [DefaultValue](https://spec.graphql.org/October2021/#DefaultValue)  | `oksa.alpha.api/default`                                  |
+  | `:directives` | Variable directives, see also [Directives](https://spec.graphql.org/October2021/#Directives)             | `oksa.alpha.api/directives` or `oksa.alpha.api/directive` |
+
+  Examples:
+
+  ```
+  (opts (variable :fooVar :FooType))
+  ; => {:variables [:fooVar :FooType]}
+
+  (opts (variable :foo (opts (directives :fooDirective :barDirective)
+                             (default 123))
+          :Bar))
+  ; => {:variables [:foo
+  ;                 {:directives [:fooDirective :barDirective], :default 123}
+  ;                 :Bar]}
+  ```
+
+  See also [VariableDefinitions](https://spec.graphql.org/October2021/#VariableDefinitions)."
+  ([variable-name variable-type]
+   (variable variable-name nil variable-type))
+  ([variable-name opts variable-type]
+   (-validate (or (-type? variable-type) (-list? variable-type))
+              "invalid type given, expected `oksa.alpha.api/type`, `oksa.alpha.api/type!`, keyword (naked type), `oksa.alpha.api/list`, or `oksa.alpha.api/list!`")
+   (let [variable-type* (if (or (keyword? variable-type) (string? variable-type))
+                          (type variable-type)
+                          variable-type)
+         form (cond-> [variable-name]
+                (some? opts) (conj opts)
+                true (conj (protocol/-form variable-type*)))
+         variable* (-parse-or-throw :oksa.parse/VariableDefinitions
+                                    form
+                                    oksa.parse/-variable-definitions-parser
+                                    "invalid variable definitions")]
+     (reify
+       AST
+       (-type [_] :oksa.parse/VariableDefinitions)
+       (-form [_] form)
+       (-parsed-form [_] variable*)
+       (-opts [_] (update opts :directives (partial oksa.util/transform-malli-ast oksa.parse/-transform-map)))
+       UpdateableOption
+       (-update-key [_] :variables)
+       (-update-fn [this] #((fnil into -variables-empty-state) % (protocol/-form this)))))))
+
+(defn variables
+  "Returns `variable-definitions` under key `:variables`. Used directly within `oksa.alpha.api/opts`.
+
+  Expects `variable-definitions` to be pair(s) of variables and types where variable is a string or a keyword (that conforms to [Variable](https://spec.graphql.org/October2021/#Variable)) and where type is a string or keyword that conforms to [Type](https://spec.graphql.org/October2021/#Type).
+
+  Example:
+
+  ```
+  (opts (variables :fooVar :FooType
+                   :barVar :BarType))
+  ; => {:variables [:fooVar :FooType :barVar :BarType]}
+  ```
+
+  See also [VariableDefinitions](https://spec.graphql.org/October2021/#VariableDefinitions)."
+  [& variable-definitions]
+  (-validate (= (mod (count variable-definitions) 2) 0) "uneven amount of arguments, expected key-value pairs")
+  (let [variable-definitions* (partition 2 variable-definitions)]
+    (-validate (every? (fn [[_ v]] (or (-type? v) (-list? v))) variable-definitions*) "invalid variable types given, expected `oksa.alpha.api/type`, `oksa.alpha.api/type!`, keyword (naked type), `oksa.alpha.api/list`, or `oksa.alpha.api/list!`")
+    (let [form (->> variable-definitions*
+                    (reduce (fn [acc [variable-name variable-type]]
+                              (let [variable-type* (if (or (keyword? variable-type) (string? variable-type))
+                                                     (type variable-type)
+                                                     variable-type)]
+                                (into acc [variable-name (protocol/-form variable-type*)])))
+                            []))
+          variables* (-parse-or-throw :oksa.parse/VariableDefinitions
+                                      form
+                                      oksa.parse/-variable-definitions-parser
+                                      "invalid variable definitions")]
+      (reify
+        AST
+        (-type [_] :oksa.parse/VariableDefinitions)
+        (-form [_] form)
+        (-parsed-form [_] variables*)
+        (-opts [_] (update opts :directives (partial oksa.util/transform-malli-ast oksa.parse/-transform-map)))
+        UpdateableOption
+        (-update-key [_] :variables)
+        (-update-fn [this] #((fnil into -variables-empty-state) % (protocol/-form this)))))))
+
+(defn default
+  "Returns default `value` under `:default` key. Used directly within `oksa.alpha.api/opts`.
+
+  Example:
+
+  ```
+  (opts (variable :fooVar (opts (default 123)) :Foo))
+  ; => {:variables [:fooVar {:default 123} :Foo]}
+  ```
+
+  See also [DefaultValue](https://spec.graphql.org/October2021/#DefaultValue)."
+  [value]
+  (let [value* (-parse-or-throw :oksa.parse/Value
+                                value
+                                oksa.parse/-value-parser
+                                "invalid value")]
+    (reify
+      AST
+      (-type [_] :oksa.parse/Value)
+      (-form [_] value)
+      (-parsed-form [_] value*)
+      (-opts [_] {})
+      UpdateableOption
+      (-update-key [_] :default)
+      (-update-fn [_] (constantly value*)))))
+
+(defn gql
+  "Returns a GraphQL request string for a given `obj`.
+
+  Expects `obj` to implement `oksa.alpha.protocol/Representable` or will throw.
+
+  The following functions implement `oksa.alpha.protocol/Representable`:
+  - `oksa.alpha.api/document`
+  - `oksa.alpha.api/select`
+  - `oksa.alpha.api/query`
+  - `oksa.alpha.api/mutation`
+  - `oksa.alpha.api/subscription`
+  - `oksa.alpha.api/fragment`"
+  [obj]
+  (-validate (satisfies? Representable obj) "Object must be Representable (one of `oksa.alpha.api/document`, `oksa.alpha.api/select`, `oksa.alpha.api/query`, `oksa.alpha.api/mutation`, `oksa.alpha.api/subscription`, or `oksa.alpha.api/fragment`)")
+  (protocol/-gql obj))

--- a/src/oksa/alpha/protocol.cljc
+++ b/src/oksa/alpha/protocol.cljc
@@ -1,0 +1,24 @@
+(ns oksa.alpha.protocol)
+
+(defprotocol AST
+  (-type [this] "returns the type of the parsed object")
+  (-opts [this] "returns the options of the token")
+  (-parsed-form [this] "returns the malli-parsed AST")
+  (-form [this] "returns a malli-parseable representation of the token"))
+
+(defprotocol Serializable
+  "Represents an object which can be serialized to represent a partial GraphQL document."
+  (-unparse [this] "produces a string representation of the GraphQL token"))
+
+(defprotocol Representable
+  "Represents an object that can be provided to `oksa.alpha.api/gql`."
+  (-gql [this] "returns a GraphQL request string"))
+
+(defprotocol UpdateableOption
+  "Represents an option that can be provided to `oksa.alpha.api/opts`."
+  (-update-key [this] "the associated key to perform the update on")
+  (-update-fn [this] "an update function provided for `clojure.core/update`"))
+
+(defprotocol Argumented
+  "Represents an option that can be `oksa.alpha.api/directive`."
+  (-arguments [this] "returns all of the arguments"))

--- a/src/oksa/core.cljc
+++ b/src/oksa/core.cljc
@@ -1,12 +1,35 @@
 (ns oksa.core
-  (:require [oksa.parse :as parse]
+  (:require [oksa.alpha.api :as api]
+            [oksa.parse :as parse]
             [oksa.unparse :as unparse]))
 
+(defn explain
+  "Explains `x` using `malli.core/explain`.
+
+  Expects `x` to be a malli-like vector."
+  [x]
+  (parse/explain x))
+
 (defn unparse
+  "Attempts to parse `x` and produce a GraphQL request string.
+
+  Expects `x` to be a malli-like vector."
   [x]
   (-> (parse/to-ast x)
       (unparse/unparse)))
 
-(defn explain
-  [x]
-  (parse/explain x))
+(defn gql
+  "Attempts to produce a GraphQL request string from `objs`.
+
+  Expects `objs` to either be instance(s) of `oksa.alpha.protocol/Representable` or malli-like vector(s).
+
+  See `oksa.alpha.api/api`, `README.md`, or tests for examples."
+  [& objs]
+  (apply str
+         (clojure.string/join
+          (System/lineSeparator)
+          (map (fn [obj]
+                 (if (satisfies? oksa.alpha.protocol/Representable obj)
+                   (api/gql obj)
+                   (unparse obj)))
+               objs))))

--- a/src/oksa/core.cljc
+++ b/src/oksa/core.cljc
@@ -27,7 +27,8 @@
   [& objs]
   (apply str
          (clojure.string/join
-          (System/lineSeparator)
+          #?(:clj  (System/lineSeparator)
+             :cljs (with-out-str (newline)))
           (map (fn [obj]
                  (if (satisfies? oksa.alpha.protocol/Representable obj)
                    (api/gql obj)

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -2,11 +2,11 @@
   (:require [malli.core :as m]
             [oksa.util :as util]))
 
-(def ^:private transform-map
+(def -transform-map
   (letfn [(operation [operation-type opts xs]
             (into [operation-type (-> opts
-                                      (update :directives (partial util/transform-malli-ast transform-map))
-                                      (update :variables (partial util/transform-malli-ast transform-map)))]
+                                      (update :directives (partial util/transform-malli-ast -transform-map))
+                                      (update :variables (partial util/transform-malli-ast -transform-map)))]
                   xs))
           (document [opts xs]
             (into [:document opts] xs))
@@ -14,20 +14,20 @@
             (assert (some? (:name opts)) "missing name")
             (into [:fragment (update opts
                                      :directives
-                                     (partial util/transform-malli-ast transform-map))]
+                                     (partial util/transform-malli-ast -transform-map))]
                   xs))
           (fragment-spread [opts & xs]
             (assert (some? (:name opts)) "missing name")
             (into [:fragment-spread
                    (update opts
                            :directives
-                           (partial util/transform-malli-ast transform-map))]
+                           (partial util/transform-malli-ast -transform-map))]
                   xs))
           (inline-fragment [opts xs]
             (assert (not (some? (:name opts))) "inline fragments can't have name")
             (into [:inline-fragment (update opts
                                             :directives
-                                            (partial util/transform-malli-ast transform-map))]
+                                            (partial util/transform-malli-ast -transform-map))]
                   xs))
           (selection-set [xs]
            (into [:selectionset {}]
@@ -35,11 +35,11 @@
                         (let [[selection-type value] node]
                           (cond-> (into [:selection {}]
                                         [(case selection-type
-                                           ::NakedField (util/transform-malli-ast transform-map [::Field [value {}]])
-                                           ::WrappedField (util/transform-malli-ast transform-map value)
-                                           ::FragmentSpread (util/transform-malli-ast transform-map value)
-                                           ::InlineFragment (util/transform-malli-ast transform-map value))])
-                            (some? children) (into [(util/transform-malli-ast transform-map children)]))))
+                                           ::NakedField (util/transform-malli-ast -transform-map [::Field [value {}]])
+                                           ::WrappedField (util/transform-malli-ast -transform-map value)
+                                           ::FragmentSpread (util/transform-malli-ast -transform-map value)
+                                           ::InlineFragment (util/transform-malli-ast -transform-map value))])
+                            (some? children) (into [(util/transform-malli-ast -transform-map children)]))))
                       xs)))]
     {:oksa/document document
      :<> document
@@ -61,7 +61,7 @@
      ::Field (fn [[name opts & xs]]
                (into [:selection {} [:field (merge (update opts
                                                            :directives
-                                                           (partial util/transform-malli-ast transform-map))
+                                                           (partial util/transform-malli-ast -transform-map))
                                                    {:name name})]]
                      (filterv some? xs)))
      ::Directives (partial into [])
@@ -70,7 +70,7 @@
      ::VariableDefinitions (fn [xs]
                              (map (fn [[variable-name opts type :as _variable-definition]]
                                     [variable-name
-                                     (update opts :directives (partial util/transform-malli-ast transform-map))
+                                     (update opts :directives (partial util/transform-malli-ast -transform-map))
                                      type])
                                   xs))
      ::TypeName (fn [type-name] [type-name {}])
@@ -89,154 +89,176 @@
 (def ^:private re-enum-value (re-pattern (str "(?!(true|false|null))" name-pattern)))
 
 (def ^:private reserved-keywords
-  (set (filter #(some-> % namespace (= "oksa")) (keys transform-map))))
+  (set (filter #(some-> % namespace (= "oksa")) (keys -transform-map))))
 
-(def ^:private graphql-dsl-lang
-  [:schema {:registry {::Document [:or
-                                   [:schema [:ref ::Definition]]
-                                   [:cat
-                                    [:enum :oksa/document :<>]
-                                    [:? :map]
-                                    [:+ [:schema [:ref ::Definition]]]]]
-                       ::Definition [:schema [:ref ::ExecutableDefinition]]
-                       ::ExecutableDefinition [:or
-                                               [:schema [:ref ::OperationDefinition]]
-                                               [:schema [:ref ::FragmentDefinition]]]
-                       ::FragmentDefinition [:cat
-                                             [:enum :oksa/fragment :#]
-                                             [:? [:map
-                                                  [:name {:optional false}
-                                                   [:ref ::FragmentName]]
-                                                  [:on [:ref ::Name]]
-                                                  [:directives {:optional true}
-                                                   [:schema [:ref ::Directives]]]]]
-                                             [:+ [:schema [:ref ::SelectionSet]]]]
-                       ::OperationDefinition [:or
-                                              [:cat
-                                               [:enum :oksa/query :oksa/mutation :oksa/subscription]
-                                               [:? [:map
-                                                    [:name {:optional true} [:ref ::Name]]
-                                                    [:variables {:optional true}
-                                                     [:schema [:ref ::VariableDefinitions]]]
-                                                    [:directives {:optional true}
-                                                     [:schema [:ref ::Directives]]]]]
-                                               [:+ [:schema [:ref ::SelectionSet]]]]
-                                              [:schema [:ref ::SelectionSet]]]
-                       ::VariableDefinitions [:orn [::VariableDefinitions
-                                                    [:+ [:cat
-                                                         [:schema [:ref ::VariableName]]
-                                                         [:? [:map
-                                                              [:directives {:optional true}
-                                                               [:schema [:ref ::Directives]]]
-                                                              [:default {:optional true}
-                                                               [:schema [:ref ::Value]]]]]
-                                                         [:schema [:ref ::Type]]]]]]
-                       ::Type [:orn
-                               [::TypeName [:schema [:schema [:ref ::TypeName]]]]
-                               [::NamedTypeOrNonNullNamedType [:schema [:ref ::NamedTypeOrNonNullNamedType]]]
-                               [::ListTypeOrNonNullListType [:schema [:ref ::ListTypeOrNonNullListType]]]
-                               [::AbbreviatedListType [:schema [:ref ::ListType]]]
-                               [::AbbreviatedNonNullListType [:schema [:ref ::NonNullListType]]]]
-                       ::TypeName [:and
-                                   [:not [:enum :oksa/list]]
-                                   :keyword
-                                   [:fn {:error/message (str "invalid character range for name, should follow the pattern: " re-type-name)}
-                                    (fn [x] (re-matches re-type-name (name x)))]]
-                       ::TypeOpts [:map
-                                   [:non-null :boolean]]
-                       ::NamedTypeOrNonNullNamedType [:cat
-                                                      [:schema [:ref ::TypeName]]
-                                                      [:schema [:ref ::TypeOpts]]]
-                       ::ListType [:cat [:schema [:ref ::Type]]]
-                       ::NonNullListType [:cat [:= :!] [:schema [:ref ::Type]]]
-                       ::ListTypeOrNonNullListType [:cat
-                                                    [:= :oksa/list]
-                                                    [:? [:schema [:ref ::TypeOpts]]]
-                                                    [:schema [:ref ::Type]]]
-                       ::SelectionSet [:orn
-                                       [::SelectionSet [:+ [:catn
-                                                            [::node [:schema [:ref ::Selection]]]
-                                                            [::children [:? [:schema [:ref ::SelectionSet]]]]]]]]
-                       ::Selection [:orn
-                                    [::WrappedField [:schema [:ref ::Field]]]
-                                    [::NakedField [:schema [:ref ::NakedField]]]
-                                    [::FragmentSpread [:schema [:ref ::FragmentSpread]]]
-                                    [::InlineFragment [:schema [:ref ::InlineFragment]]]]
-                       ::Field [:orn [::Field [:cat
-                                               [:schema [:ref ::FieldName]]
-                                               [:map
-                                                [:alias {:optional true} [:ref ::Name]]
-                                                [:arguments {:optional true}
-                                                 [:ref ::Arguments]]
-                                                [:directives {:optional true}
-                                                 [:ref ::Directives]]]
-                                               [:? [:schema [:ref ::SelectionSet]]]]]]
-                       ::NakedField [:schema [:ref ::FieldName]]
-                       ::FieldName [:and
-                                    [:schema [:ref ::Name]]
-                                    [:fn #(not (reserved-keywords %))]]
-                       ::FragmentSpread [:cat
-                                         [:enum :oksa/fragment-spread :...]
-                                         [:? [:map
-                                              [:name {:optional false}
-                                               [:ref ::FragmentName]]
-                                              [:directives {:optional true}
-                                               [:ref ::Directives]]]]]
-                       ::InlineFragment [:cat
-                                         [:enum :oksa/inline-fragment :...]
-                                         [:? [:map
-                                              [:directives {:optional true}
-                                               [:ref ::Directives]]
-                                              [:on {:optional true}
-                                               [:ref ::Name]]]]
-                                         [:+ [:schema [:ref ::SelectionSet]]]]
-                       ::Name [:and [:or :keyword :string]
-                               [:fn {:error/message (str "invalid character range for name, should follow the pattern: " re-name)}
-                                (fn [x] (re-matches re-name (name x)))]]
-                       ::VariableName [:and [:or :keyword :string]
-                                       [:fn {:error/message (str "invalid character range for variable name, should follow the pattern: " re-variable-name)}
-                                        (fn [x] (re-matches re-variable-name (name x)))]]
-                       ::FragmentName [:and [:or :keyword :string]
-                                       [:fn {:error/message (str "invalid character range for fragment name, should follow the pattern: " re-fragment-name)}
-                                        (fn [x] (re-matches re-fragment-name (name x)))]]
-                       ::Value [:or
-                                number?
-                                :string
-                                :boolean
-                                :nil
-                                [:and :keyword
-                                 [:fn
-                                  {:error/message (str "invalid character range for value, should follow either: " re-enum-value ", or: " re-variable-reference)}
-                                  (fn [x]
-                                    (let [s (name x)]
-                                      (or (re-matches re-variable-reference s)
-                                          (re-matches re-enum-value s))))]]
-                                coll?
-                                :map]
-                       ::Arguments [:map-of [:ref ::Name] [:ref ::Value]]
-                       ::Directives [:orn [::Directives [:+ [:orn
-                                                             [::DirectiveName [:schema [:ref ::DirectiveName]]]
-                                                             [::Directive [:schema [:ref ::Directive]]]]]]]
-                       ::Directive [:cat
-                                    [:schema [:ref ::DirectiveName]]
-                                    [:? [:map
-                                         [:arguments {:optional true}
-                                          [:ref ::Arguments]]]]]
-                       ::DirectiveName [:ref ::Name]}}
-   ::Document])
+(def ^:private registry
+  {::Document [:or
+               [:schema [:ref ::Definition]]
+               [:cat
+                [:enum :oksa/document :<>]
+                [:? :map]
+                [:+ [:schema [:ref ::Definition]]]]]
+   ::Definition [:schema [:ref ::ExecutableDefinition]]
+   ::ExecutableDefinition [:or
+                           [:schema [:ref ::OperationDefinition]]
+                           [:schema [:ref ::FragmentDefinition]]]
+   ::FragmentDefinition [:cat
+                         [:enum :oksa/fragment :#]
+                         [:map
+                          [:name {:optional false}
+                           [:ref ::FragmentName]]
+                          [:on [:ref ::Name]]
+                          [:directives {:optional true}
+                           [:schema [:ref ::Directives]]]]
+                         [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+   ::OperationDefinition [:or
+                          [:cat
+                           [:enum :oksa/query :oksa/mutation :oksa/subscription]
+                           [:? [:map
+                                [:name {:optional true} [:ref ::Name]]
+                                [:variables {:optional true}
+                                 [:schema [:ref ::VariableDefinitions]]]
+                                [:directives {:optional true}
+                                 [:schema [:ref ::Directives]]]]]
+                           [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+                          [:schema [:ref ::SelectionSet]]]
+   ::VariableDefinitions [:orn [::VariableDefinitions
+                                [:+ [:cat
+                                     [:schema [:ref ::VariableName]]
+                                     [:? [:map
+                                          [:directives {:optional true}
+                                           [:schema [:ref ::Directives]]]
+                                          [:default {:optional true}
+                                           [:schema [:ref ::Value]]]]]
+                                     [:schema [:ref ::Type]]]]]]
+   ::Type [:orn
+           [::TypeName [:schema [:schema [:ref ::TypeName]]]]
+           [::NamedTypeOrNonNullNamedType [:schema [:ref ::NamedTypeOrNonNullNamedType]]]
+           [::ListTypeOrNonNullListType [:schema [:ref ::ListTypeOrNonNullListType]]]
+           [::AbbreviatedListType [:schema [:ref ::ListType]]]
+           [::AbbreviatedNonNullListType [:schema [:ref ::NonNullListType]]]]
+   ::TypeName [:and
+               [:not [:enum :oksa/list]]
+               [:or :keyword :string]
+               [:fn {:error/message (str "invalid character range for name, should follow the pattern: " re-type-name)}
+                (fn [x] (re-matches re-type-name (name x)))]]
+   ::TypeOpts [:map
+               [:non-null :boolean]]
+   ::NamedTypeOrNonNullNamedType [:cat
+                                  [:schema [:ref ::TypeName]]
+                                  [:schema [:ref ::TypeOpts]]]
+   ::ListType [:cat [:schema [:ref ::Type]]]
+   ::NonNullListType [:cat [:= :!] [:schema [:ref ::Type]]]
+   ::ListTypeOrNonNullListType [:cat
+                                [:= :oksa/list]
+                                [:? [:schema [:ref ::TypeOpts]]]
+                                [:schema [:ref ::Type]]]
+   ::SelectionSet [:orn
+                   [::SelectionSet [:+ [:catn
+                                        [::node [:schema [:ref ::Selection]]]
+                                        [::children [:? [:schema [:ref ::SelectionSet]]]]]]]]
+   ::Selection [:orn
+                [::WrappedField [:schema [:ref ::Field]]]
+                [::NakedField [:schema [:ref ::NakedField]]]
+                [::FragmentSpread [:schema [:ref ::FragmentSpread]]]
+                [::InlineFragment [:schema [:ref ::InlineFragment]]]]
+   ::Field [:orn [::Field [:cat
+                           [:schema [:ref ::FieldName]]
+                           [:map
+                            [:alias {:optional true} [:ref ::Alias]]
+                            [:arguments {:optional true}
+                             [:ref ::Arguments]]
+                            [:directives {:optional true}
+                             [:ref ::Directives]]]
+                           [:? [:schema [:ref ::SelectionSet]]]]]]
+   ::NakedField [:schema [:ref ::FieldName]]
+   ::FieldName [:and
+                [:schema [:ref ::Name]]
+                [:fn #(not (reserved-keywords %))]]
+   ::FragmentSpread [:cat
+                     [:enum :oksa/fragment-spread :...]
+                     [:? [:map
+                          [:name {:optional false}
+                           [:ref ::FragmentName]]
+                          [:directives {:optional true}
+                           [:ref ::Directives]]]]]
+   ::InlineFragment [:cat
+                     [:enum :oksa/inline-fragment :...]
+                     [:? [:map
+                          [:directives {:optional true}
+                           [:ref ::Directives]]
+                          [:on {:optional true}
+                           [:ref ::Name]]]]
+                     [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+   ::Alias [:schema [:ref ::Name]]
+   ::Name [:and [:or :keyword :string]
+           [:fn {:error/message (str "invalid character range for name, should follow the pattern: " re-name)}
+            (fn [x] (re-matches re-name (name x)))]]
+   ::VariableName [:and [:or :keyword :string]
+                   [:fn {:error/message (str "invalid character range for variable name, should follow the pattern: " re-variable-name)}
+                    (fn [x] (re-matches re-variable-name (name x)))]]
+   ::FragmentName [:and [:or :keyword :string]
+                   [:fn {:error/message (str "invalid character range for fragment name, should follow the pattern: " re-fragment-name)}
+                    (fn [x] (re-matches re-fragment-name (name x)))]]
+   ::Value [:or
+            number?
+            :string
+            :boolean
+            :nil
+            [:and :keyword
+             [:fn
+              {:error/message (str "invalid character range for value, should follow either: " re-enum-value ", or: " re-variable-reference)}
+              (fn [x]
+                (let [s (name x)]
+                  (or (re-matches re-variable-reference s)
+                      (re-matches re-enum-value s))))]]
+            coll?
+            :map]
+   ::Arguments [:map-of [:ref ::Name] [:ref ::Value]]
+   ::Directives [:orn [::Directives [:+ [:orn
+                                         [::DirectiveName [:schema [:ref ::DirectiveName]]]
+                                         [::Directive [:schema [:ref ::Directive]]]]]]]
+   ::Directive [:cat
+                [:schema [:ref ::DirectiveName]]
+                [:? [:map
+                     [:arguments {:optional true}
+                      [:ref ::Arguments]]]]]
+   ::DirectiveName [:ref ::Name]})
 
-(def ^:private graphql-dsl-parser (m/parser graphql-dsl-lang))
+(defn -graphql-dsl-lang
+  [schema]
+  [:schema {:registry registry} schema])
+
+(def -graphql-dsl-parser (m/parser (-graphql-dsl-lang ::Document)))
+(def -field-parser (m/parser (-graphql-dsl-lang ::Field)))
+(def -fragment-spread-parser (m/parser (-graphql-dsl-lang ::FragmentSpread)))
+(def -inline-fragment-parser (m/parser (-graphql-dsl-lang ::InlineFragment)))
+(def -naked-field-parser (m/parser (-graphql-dsl-lang ::NakedField)))
+(def -selection-set-parser (m/parser (-graphql-dsl-lang ::SelectionSet)))
+(def -operation-definition-parser (m/parser (-graphql-dsl-lang ::OperationDefinition)))
+(def -fragment-definition-parser (m/parser (-graphql-dsl-lang ::FragmentDefinition)))
+(def -directives-parser (m/parser (-graphql-dsl-lang ::Directives)))
+(def -directive-parser (m/parser (-graphql-dsl-lang ::Directive)))
+(def -directive-name-parser (m/parser (-graphql-dsl-lang ::DirectiveName)))
+(def -arguments-parser (m/parser (-graphql-dsl-lang ::Arguments)))
+(def -alias-parser (m/parser (-graphql-dsl-lang ::Alias)))
+(def -name-parser (m/parser (-graphql-dsl-lang ::Name)))
+(def -value-parser (m/parser (-graphql-dsl-lang ::Value)))
+(def -type-name-parser (m/parser (-graphql-dsl-lang ::TypeName)))
+(def -named-type-or-non-null-named-type-parser (m/parser (-graphql-dsl-lang ::NamedTypeOrNonNullNamedType)))
+(def -list-type-or-non-null-list-type-parser (m/parser (-graphql-dsl-lang ::ListTypeOrNonNullListType)))
+(def -variable-definitions-parser (m/parser (-graphql-dsl-lang ::VariableDefinitions)))
 
 (defn- parse
   [x]
-  (let [parsed (graphql-dsl-parser x)]
+  (let [parsed (-graphql-dsl-parser x)]
     (if (not= :malli.core/invalid parsed)
       parsed
       (throw (ex-info "invalid form" {})))))
 
 (defn- xf
   [ast]
-  (util/transform-malli-ast transform-map ast))
+  (util/transform-malli-ast -transform-map ast))
 
 (defn to-ast
   [x]
@@ -245,4 +267,4 @@
 
 (defn explain
   [x]
-  (m/explain graphql-dsl-lang x))
+  (m/explain (-graphql-dsl-lang ::Document) x))

--- a/test/oksa/alpha/api_test.cljc
+++ b/test/oksa/alpha/api_test.cljc
@@ -1,0 +1,472 @@
+(ns oksa.alpha.api-test
+  (:require [#?(:clj clojure.test
+                :cljs cljs.test) :as t]
+            [oksa.alpha.api :as api])
+  #?(:clj (:import [graphql.parser Parser])))
+
+(defn unparse-and-validate
+  [x]
+  (let [graphql-query (api/gql x)]
+    #?(:clj (Parser/parse graphql-query))
+    graphql-query))
+
+(t/deftest unparse-test
+  (t/testing "query"
+    (t/is (= "query {foo}"
+             (unparse-and-validate (api/query (api/select :foo)))))
+    (t/is (= "query {foo bar}"
+             (unparse-and-validate (api/query (api/select :foo :bar)))))
+    (t/is (= "query {bar{qux{baz}}}"
+             (unparse-and-validate
+              (api/query
+               (api/select :bar
+                 (api/select :qux
+                   (api/select :baz)))))))
+    (t/is (= "query {foo bar{qux{baz}}}"
+             (unparse-and-validate
+              (api/query
+               (api/select :foo :bar
+                 (api/select :qux
+                   (api/select :baz)))))))
+    (t/is (= "query Foo {foo}"
+             (unparse-and-validate (api/query (api/opts (api/name :Foo)) (api/select :foo)))))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate (api/query (api/query (api/select :baz))))))
+      (t/is (= "query {query{baz}}"
+               (unparse-and-validate
+                (api/query (api/select :query (api/select :baz))))))
+      (t/is (= "{query{query{baz}}}" (unparse-and-validate
+                                      (api/select :query
+                                        (api/select :query
+                                          (api/select :baz))))))))
+  (t/testing "mutation"
+    (t/is (= "mutation {foo}" (unparse-and-validate (api/mutation (api/select :foo)))))
+    (t/is (= "mutation {foo bar}" (unparse-and-validate (api/mutation (api/select :foo :bar)))))
+    (t/is (= "mutation {bar{qux{baz}}}" (unparse-and-validate
+                                         (api/mutation
+                                          (api/select :bar
+                                            (api/select :qux
+                                              (api/select :baz)))))))
+    (t/is (= "mutation {foo bar{qux{baz}}}" (unparse-and-validate
+                                             (api/mutation
+                                              (api/select :foo :bar
+                                                (api/select :qux
+                                                  (api/select :baz)))))))
+    (t/is (= "mutation Foo {foo}"
+             (unparse-and-validate
+              (api/mutation (api/opts (api/name :Foo)) (api/select :foo)))))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate (api/mutation (api/mutation (api/select :baz))))))
+      (t/is (= "mutation {mutation{baz}}" (unparse-and-validate
+                                           (api/mutation (api/select :mutation (api/select :baz))))))
+      (t/is (= "{mutation{mutation{baz}}}" (unparse-and-validate
+                                            (api/select :mutation
+                                              (api/select :mutation
+                                                (api/select :baz))))))))
+  (t/testing "subscription"
+    (t/is (= "subscription {foo}" (unparse-and-validate (api/subscription (api/select :foo)))))
+    (t/is (= "subscription {foo bar}" (unparse-and-validate (api/subscription (api/select :foo :bar)))))
+    (t/is (= "subscription {bar{qux{baz}}}" (unparse-and-validate
+                                             (api/subscription
+                                              (api/select :bar
+                                                (api/select :qux
+                                                  (api/select :baz)))))))
+    (t/is (= "subscription {foo bar{qux{baz}}}" (unparse-and-validate
+                                                 (api/subscription
+                                                  (api/select :foo :bar
+                                                    (api/select :qux
+                                                      (api/select :baz)))))))
+    (t/is (= "subscription Foo {foo}" (unparse-and-validate (api/subscription (api/opts (api/name :Foo)) (api/select :foo)))))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate (api/subscription (api/subscription (api/select :baz))))))
+      (t/is (= "subscription {subscription{baz}}" (unparse-and-validate
+                                                   (api/subscription (api/select :subscription (api/select :baz))))))
+      (t/is (= "{subscription{subscription{baz}}}" (unparse-and-validate
+                                                    (api/select :subscription
+                                                      (api/select :subscription
+                                                        (api/select :baz))))))))
+  (t/testing "selection set"
+    (t/is (= "{foo}"
+             (unparse-and-validate (api/select :foo))
+             (unparse-and-validate (api/select (api/field :foo)))))
+    (t/is (= "{foo bar}"
+             (unparse-and-validate (api/select
+                                     (api/field :foo)
+                                     (api/field :bar)))
+             (unparse-and-validate (api/select :foo :bar))))
+    (t/is (= "{bar{qux{baz}}}"
+             (unparse-and-validate (api/select :bar
+                                     (api/select :qux
+                                      (api/select :baz))))
+             (unparse-and-validate (api/select (api/field :bar)
+                                     (api/select (api/field :qux)
+                                       (api/select (api/field :baz)))))
+             (unparse-and-validate (api/select
+                                     (api/field :bar
+                                       (api/select
+                                         (api/field :qux
+                                           (api/select :baz))))))))
+    (t/is (= "{foo bar{qux{baz}}}"
+             (unparse-and-validate (api/select :foo :bar
+                                     (api/select :qux
+                                       (api/select :baz))))
+             (unparse-and-validate (api/select :foo
+                                     (api/field :bar
+                                       (api/select
+                                         (api/field :qux
+                                           (api/select :baz))))))))
+    (t/is (= "{foo bar{qux baz}}"
+             (unparse-and-validate (api/select :foo :bar
+                                     (api/select :qux :baz)))
+             (unparse-and-validate (api/select :foo
+                                     (api/field :bar
+                                       (api/select
+                                         (api/field :qux)
+                                         (api/field :baz)))))))
+    (t/is (= "{foo{bar{baz qux} frob}}"
+             (unparse-and-validate (api/select :foo
+                                    (api/select :bar
+                                      (api/select :baz :qux)
+                                      :frob)))
+             (unparse-and-validate (api/select
+                                     (api/field :foo
+                                       (api/select
+                                         (api/field :bar
+                                           (api/select
+                                             (api/field :baz)
+                                             (api/field :qux)))
+                                         :frob))))))
+    (t/testing "support strings as field names"
+      (t/is (= "{foo}"
+               (unparse-and-validate (api/select "foo"))
+               (unparse-and-validate (api/select :foo))
+               (unparse-and-validate (api/select (api/field "foo")))
+               (unparse-and-validate (api/select (api/field :foo))))))
+    (t/testing "arguments"
+      (t/is (= "{foo}"
+               (unparse-and-validate (api/select (api/field :foo (api/opts (api/arguments)))))))
+      (t/is (= "{foo(a:1, b:\"hello world\", c:true, d:null, e:foo, f:[1 2 3], g:{frob:{foo:1, bar:2}}, h:$fooVar)}"
+               (unparse-and-validate (api/select (api/field :foo
+                                                   (api/opts
+                                                    (api/arguments :a 1
+                                                                   :b "hello world"
+                                                                   :c true
+                                                                   :d nil
+                                                                   :e :foo
+                                                                   :f [1 2 3]
+                                                                   :g {:frob {:foo 1
+                                                                              :bar 2}}
+                                                                   :h :$fooVar)))))
+               (unparse-and-validate (api/select (api/field :foo
+                                                   (api/opts
+                                                    (api/argument :a 1)
+                                                    (api/argument :b "hello world")
+                                                    (api/argument :c true)
+                                                    (api/argument :d nil)
+                                                    (api/argument :e :foo)
+                                                    (api/argument :f [1 2 3])
+                                                    (api/argument :g {:frob {:foo 1
+                                                                             :bar 2}})
+                                                    (api/argument :h :$fooVar)))))))
+      #?(:clj (t/is (= "{foo(a:0.3333333333333333)}"
+                       (unparse-and-validate (api/select (api/field :foo (api/opts (api/argument :a 1/3)))))
+                       (unparse-and-validate (api/select (api/field :foo (api/opts (api/arguments :a 1/3))))))))
+      (t/testing "escaping special characters"
+        (t/is (= "{fooField(foo:\"\\\"\")}"
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/argument :foo "\"")))))
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/arguments :foo "\"")))))))
+        (t/is (= "{fooField(foo:\"\\\\\")}"
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/argument :foo "\\")))))
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/arguments :foo "\\")))))))
+        (t/is (= "{fooField(foo:\"foo\\b\\f\\r\\n\\tbar\")}"
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/argument :foo "foo\b\f\r\n\tbar")))))
+                 (unparse-and-validate (api/select (api/field :fooField (api/opts (api/arguments :foo "foo\b\f\r\n\tbar"))))))))))
+  (t/testing "document"
+    (t/is (= "{foo}"
+             (unparse-and-validate (api/document (api/select :foo)))))
+    (t/is (= "{foo}\n{bar}"
+             (unparse-and-validate (api/document (api/select :foo) (api/select :bar)))))
+    (t/is (= "{foo}\nquery {bar}\nmutation {qux}\nsubscription {baz}\nfragment foo on Foo{bar}"
+             (unparse-and-validate (api/document
+                                    (api/select :foo)
+                                    (api/query (api/select :bar))
+                                    (api/mutation (api/select :qux))
+                                    (api/subscription (api/select :baz))
+                                    (api/fragment (api/opts (api/name :foo)
+                                                            (api/on :Foo))
+                                      (api/select :bar))))))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate (api/document (api/document (api/select :baz))))))
+      (t/is (= "{document{baz}}" (unparse-and-validate (api/document (api/select :document (api/select :baz))))))
+      (t/is (= "{document{document{baz}}}" (unparse-and-validate (api/select :document (api/select :document (api/select :baz))))))))
+  (t/testing "fragment"
+    (t/is (= "fragment Foo on Bar{foo}"
+             (unparse-and-validate (api/fragment (api/opts (api/name :Foo)
+                                                           (api/on :Bar))
+                                     (api/select :foo)))))
+    (t/is (= "fragment Foo on Bar{foo bar}"
+             (unparse-and-validate (api/fragment (api/opts (api/name :Foo)
+                                                           (api/on :Bar))
+                                     (api/select :foo :bar)))))
+    (t/is (= "fragment Foo on Bar{bar{qux{baz}}}"
+             (unparse-and-validate (api/fragment (api/opts (api/name :Foo)
+                                                           (api/on :Bar))
+                                     (api/select :bar
+                                       (api/select :qux
+                                         (api/select :baz)))))))
+    (t/is (= "fragment Foo on Bar{foo bar{qux{baz}}}"
+             (unparse-and-validate (api/fragment (api/opts (api/name :Foo)
+                                                           (api/on :Bar))
+                                     (api/select :foo :bar
+                                       (api/select :qux
+                                         (api/select :baz)))))))
+    (t/testing "non-ambiguity"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error)
+                     (unparse-and-validate
+                      (api/fragment (api/opts (api/name :Foo) (api/on :Bar))
+                        (api/fragment (api/opts (api/name :Foo) (api/on :Bar))
+                          (api/select :baz))))))
+      (t/is (= "fragment Foo on Bar{fragment{baz}}"
+               (unparse-and-validate
+                (api/fragment (api/opts (api/name :Foo) (api/on :Bar))
+                  (api/select :fragment
+                    (api/select :baz))))))
+      (t/is (= "{fragment{fragment{baz}}}"
+               (unparse-and-validate (api/select :fragment
+                                       (api/select :fragment
+                                         (api/select :baz))))))))
+  (t/testing "fragment spread"
+    (t/is (= "{foo ...bar}"
+             (unparse-and-validate (api/select :foo
+                                     (api/fragment-spread (api/opts (api/name :bar))))))))
+  (t/testing "inline fragment"
+    (t/is (= "{foo ...{bar}}"
+             (unparse-and-validate (api/select :foo
+                                     (api/inline-fragment
+                                      (api/select :bar))))))
+    (t/is (= "{foo ...on Bar{bar}}"
+             (unparse-and-validate (api/select :foo
+                                     (api/inline-fragment (api/opts (api/on :Bar))
+                                       (api/select :bar)))))))
+  (t/testing "variable definitions"
+    (t/testing "named type"
+      (t/is (= "query ($fooVar:FooType){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar :FooType))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar :FooType))
+                                       (api/select :fooField))))))
+    (t/testing "non-null named type")
+    (t/is (= "query ($fooVar:FooType!){fooField}"
+             (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/type! :FooType)))
+                                     (api/select :fooField)))
+             (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/type! :FooType)))
+                                     (api/select :fooField)))))
+    (t/testing "named type within list"
+      (t/is (= "query ($fooVar:[FooType]){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list :FooType)))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list :FooType)))
+                                       (api/select :fooField))))))
+    (t/testing "non-null named type within list"
+      (t/is (= "query ($fooVar:[FooType!]){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list (api/type! :FooType))))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list (api/type! :FooType))))
+                                       (api/select :fooField))))))
+    (t/testing "named type within list"
+      (t/is (= "query ($fooVar:[BarType]!){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list! :BarType)))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list! :BarType)))
+                                       (api/select :fooField))))))
+    (t/testing "non-null type within non-null list"
+      (t/is (= "query ($fooVar:[BarType!]!){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list! (api/type! :BarType))))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list! (api/type! :BarType))))
+                                       (api/select :fooField))))))
+    (t/testing "named type within list within list"
+      (t/is (= "query ($fooVar:[[BarType]]){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list (api/list :BarType))))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list (api/list :BarType))))
+                                       (api/select :fooField))))))
+    (t/testing "non-null list within non-null list"
+      (t/is (= "query ($fooVar:[[BarType]!]!){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar (api/list! (api/list! :BarType))))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar (api/list! (api/list! :BarType))))
+                                       (api/select :fooField))))))
+    (t/testing "multiple variable definitions"
+      (t/is (= "query ($fooVar:FooType,$barVar:BarType){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable :fooVar :FooType)
+                                                          (api/variable :barVar :BarType))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables :fooVar :FooType
+                                                                         :barVar :BarType))
+                                       (api/select :fooField))))))
+    (t/testing "default values"
+      (let [graphql-query (fn [default-value]
+                            (api/query (api/opts (api/variable :fooVar (api/opts (api/default default-value)) :Foo))
+                              (api/select
+                                (api/field :fooField (api/opts (api/argument :foo :$fooVar))))))]
+        (t/is (= "query ($fooVar:Foo=123){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query 123))))
+        #?(:clj
+           (t/is (= "query ($fooVar:Foo=0.3333333333333333){fooField(foo:$fooVar)}"
+                    (unparse-and-validate (graphql-query 1/3)))))
+        (t/is (= "query ($fooVar:Foo=\"häkkyrä\"){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query "häkkyrä"))))
+        (t/is (= "query ($fooVar:Foo=true){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query true))))
+        (t/is (= "query ($fooVar:Foo=null){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query nil))))
+        (t/is (= "query ($fooVar:Foo=Frob){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query :Frob))))
+        (t/is (= "query ($fooVar:Foo=[1 \"häkkyrä\" true null Bar [1 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]] {foo:\"kikka\", bar:\"kukka\"}]){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query [1
+                                                       "häkkyrä"
+                                                       true
+                                                       nil
+                                                       :Bar
+                                                       [1 "häkkyrä" true nil :Bar ["foo" "bar"]]
+                                                       {:foo "kikka"
+                                                        "bar" "kukka"}]))))
+        (t/is (= "query ($fooVar:Foo={number:1, string:\"häkkyrä\", boolean:true, default:null, keyword:Bar, coll:[1 \"häkkyrä\" true null Bar [\"foo\" \"bar\"]]}){fooField(foo:$fooVar)}"
+                 (unparse-and-validate (graphql-query {:number 1
+                                                       :string "häkkyrä"
+                                                       :boolean true
+                                                       :default nil
+                                                       :keyword :Bar
+                                                       :coll [1 "häkkyrä" true nil :Bar ["foo" "bar"]]})))))))
+  (t/testing "variable names"
+    (doseq [variable-name [:fooVar :$fooVar "fooVar" "$fooVar"]]
+      (t/is (= "query ($fooVar:FooType){fooField}"
+               (unparse-and-validate (api/query (api/opts (api/variable variable-name :FooType))
+                                       (api/select :fooField)))
+               (unparse-and-validate (api/query (api/opts (api/variables variable-name :FooType))
+                                       (api/select :fooField)))))))
+  (t/testing "aliases"
+    (t/is (= "{bar:foo}"
+             (unparse-and-validate (api/select (api/field :foo (api/opts (api/alias :bar)))))
+             (unparse-and-validate (api/select (api/field :foo (api/opts (api/alias "bar")))))))
+    (t/is (= "{bar:foo baz:qux}"
+             (unparse-and-validate
+              (api/select
+                (api/field :foo (api/opts (api/alias :bar)))
+                (api/field :qux (api/opts (api/alias :baz)))))
+             (unparse-and-validate
+              (api/select
+                (api/field :foo (api/opts (api/alias "bar")))
+                (api/field :qux (api/opts (api/alias "baz")))))))
+    (t/is (= "{bar:foo frob baz:qux}"
+             (unparse-and-validate
+              (api/select
+                (api/field :foo (api/opts (api/alias :bar)))
+                :frob
+                (api/field :qux (api/opts (api/alias :baz)))))
+             (unparse-and-validate
+              (api/select
+                (api/field :foo (api/opts (api/alias "bar")))
+                :frob
+                (api/field :qux (api/opts (api/alias "baz"))))))))
+  (t/testing "directives"
+    (t/is (= "query @foo{foo}"
+             (unparse-and-validate (api/query (api/opts (api/directives :foo))
+                                     (api/select :foo)))))
+    (t/is (= "query @foo @bar{foo}"
+             (unparse-and-validate (api/query (api/opts (api/directives :foo :bar))
+                                     (api/select :foo)))))
+    (t/is (= "query @foo(bar:123){foo}"
+             (unparse-and-validate (api/query (api/opts (api/directive :foo (api/arguments :bar 123)))
+                                     (api/select :foo)))
+             (unparse-and-validate (api/query (api/opts (api/directive :foo (api/argument :bar 123)))
+                                     (api/select :foo)))))
+    (t/is (= "{foo@bar}"
+             (unparse-and-validate (api/select (api/field :foo (api/opts (api/directive :bar)))))
+             (unparse-and-validate (api/select (api/field :foo (api/opts (api/directives :bar)))))))
+    (t/is (= "{foo@bar qux@baz}"
+             (unparse-and-validate (api/select
+                                     (api/field :foo (api/opts (api/directive :bar)))
+                                     (api/field :qux (api/opts (api/directive :baz)))))
+             (unparse-and-validate (api/select
+                                     (api/field :foo (api/opts (api/directives :bar)))
+                                     (api/field :qux (api/opts (api/directives :baz)))))))
+    (t/is (= "{foo@foo(bar:123)}"
+             (unparse-and-validate (api/select
+                                     (api/field :foo (api/opts (api/directive :foo {:bar 123})))))))
+    (t/is (= "{...foo@fooDirective @barDirective}"
+             (unparse-and-validate (api/select (api/fragment-spread (api/opts
+                                                                     (api/name :foo)
+                                                                     (api/directives :fooDirective :barDirective)))))
+             (unparse-and-validate (api/select (api/fragment-spread (api/opts
+                                                                     (api/name :foo)
+                                                                     (api/directive :fooDirective)
+                                                                     (api/directive :barDirective)))))))
+    (t/is (= "{...foo@foo(bar:123)}"
+             (unparse-and-validate (api/select
+                                     (api/fragment-spread (api/opts
+                                                           (api/name :foo)
+                                                           (api/directive :foo (api/arguments :bar 123))))))
+             (unparse-and-validate (api/select
+                                     (api/fragment-spread (api/opts
+                                                           (api/name :foo)
+                                                           (api/directive :foo (api/argument :bar 123))))))))
+    (t/is (= "{...@fooDirective @barDirective{bar}}"
+             (unparse-and-validate (api/select
+                                     (api/inline-fragment (api/opts
+                                                           (api/directives :fooDirective :barDirective))
+                                       (api/select :bar))))
+             (unparse-and-validate (api/select
+                                     (api/inline-fragment (api/opts
+                                                           (api/directive :fooDirective)
+                                                           (api/directive :barDirective))
+                                       (api/select :bar))))))
+    (t/is (= "{...@foo(bar:123){bar}}"
+             (unparse-and-validate (api/select
+                                     (api/inline-fragment (api/opts
+                                                           (api/directive :foo (api/arguments :bar 123)))
+                                       (api/select :bar))))
+             (unparse-and-validate (api/select
+                                     (api/inline-fragment (api/opts
+                                                           (api/directive :foo (api/argument :bar 123)))
+                                       (api/select :bar))))))
+    (t/is (= "fragment foo on Foo@foo(bar:123){bar}"
+             (unparse-and-validate (api/fragment (api/opts
+                                                  (api/name :foo)
+                                                  (api/on :Foo)
+                                                  (api/directive :foo (api/argument :bar 123)))
+                                     (api/select :bar)))
+             (unparse-and-validate (api/fragment (api/opts
+                                                  (api/name :foo)
+                                                  (api/on :Foo)
+                                                  (api/directive :foo (api/arguments :bar 123)))
+                                     (api/select :bar)))))
+    (t/is (= "fragment foo on Foo@fooDirective @barDirective{bar}"
+             (unparse-and-validate (api/fragment (api/opts
+                                                  (api/name :foo)
+                                                  (api/on :Foo)
+                                                  (api/directive :fooDirective)
+                                                  (api/directive :barDirective))
+                                     (api/select :bar)))
+             (unparse-and-validate (api/fragment (api/opts
+                                                  (api/name :foo)
+                                                  (api/on :Foo)
+                                                  (api/directives :fooDirective :barDirective))
+                                     (api/select :bar)))))
+    (t/is (= "query ($foo:Bar @fooDirective){fooField}"
+             (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directives :fooDirective)) :Bar))
+                                     (api/select :fooField)))
+             (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directive :fooDirective)) :Bar))
+                                     (api/select :fooField)))))
+    (t/is (= "query ($foo:Bar @fooDirective @barDirective){fooField}"
+             (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directives :fooDirective :barDirective)) :Bar))
+                                     (api/select :fooField)))
+             (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directive :fooDirective)
+                                                                                     (api/directive :barDirective))
+                                                          :Bar))
+                                     (api/select :fooField)))))
+    (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
+             (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directive :fooDirective {:fooArg 123}))
+                                                          :Bar))
+                                     (api/select :fooField)))))))

--- a/test/oksa/test_util.cljc
+++ b/test/oksa/test_util.cljc
@@ -1,0 +1,9 @@
+(ns oksa.test-util
+  (:require [oksa.core :as core])
+  #?(:clj (:import [graphql.parser Parser])))
+
+(defn unparse-and-validate
+  [x]
+  (let [graphql-query (core/unparse x)]
+    #?(:clj (Parser/parse graphql-query))
+    graphql-query))


### PR DESCRIPTION
With this PR, it's now possible to shape up GraphQL queries using oksa with API calls. This allows for better programmatic use of oksa (tolerating nil entries by dropping them from the output), and also opens up the possibilities for better validation as well as linting.

We introduce the API in an alpha namespace to keep us the option to change things, but the whole spec should now be covered and we hope to keep the API as stable as possible.

---


Example:

```clojure
(require '[oksa.core :as oksa])
(require '[oksa.alpha.api :refer :all])

(oksa/gql (select :hello (select :world)))
;; => "{hello{world}}"
```

Longer example:

```clojure
(oksa/gql
  (query
    (select
      (field :countries (opts (argument :filter {:continent {:eq "EU"}}))
        (select :capital :currency)))))
=> "query {countries(filter:{continent:{eq:\"EU\"}}){capital currency}}"
```

Longest example:

```clojure
(oksa/gql
  (document
    (fragment (opts
                (name :Kikka)
                (on :Kukka))
      (select :kikka :kukka))
    (select :ylakikka
      (select :kikka :kukka :kakku)
      ;; v similar to ^, but allow to specify option for single field (only)
      (field :kikka (opts
                      (alias :KIKKA)
                      (directives :kakku :kukka)
                      (directive :kikkaized {:x 1 :y 2 :z 3})))
      (when false (field :conditionalKikka)) ; nils are dropped
      (fragment-spread (opts (name :FooFragment)))
      (inline-fragment (opts (on :Kikka))
        (select :kikka :kukka)))
    (query (opts (name :KikkaQuery))
      (select :specialKikka))
    (mutation (opts
                (name :saveKikka)
                (variable :myKikka (opts (default 123)) :KikkaType))
      (select :getKikka))
    (subscription (opts (name :subscribeToKikka))
      (select :realtimeKikka))))
```

```
"fragment Kikka on Kukka{kikka kukka}
 {ylakikka{kikka kukka kakku} KIKKA:kikka@kakku @kukka @kikkaized(x:1, y:2, z:3) ...FooFragment ...on Kikka{kikka kukka}}
 query KikkaQuery {specialKikka}
 mutation saveKikka ($myKikka:KikkaType=123){getKikka}
 subscription subscribeToKikka {realtimeKikka}"
```