### PR TITLE
Fix parser bug with sequential selection sets

### DIFF
--- a/src/oksa/alpha/api.cljc
+++ b/src/oksa/alpha/api.cljc
@@ -286,6 +286,7 @@
   - keyword (representing a naked field)
   - `oksa.alpha.api/fragment-spread`
   - `oksa.alpha.api/inline-fragment`
+  - `oksa.alpha.api/select` (but only directly after a field)
 
   Tolerates nil entries.
 
@@ -321,7 +322,7 @@
                                  (-selection-set? %)
                                  (-fragment-spread? %)
                                  (-inline-fragment? %)) selections*))
-               "invalid selections, expected `oksa.alpha.api/field`, keyword (naked field), `oksa.alpha.api/fragment-spread`, or `oksa.alpha.api/inline-fragment`")
+               "invalid selections, expected `oksa.alpha.api/field`, keyword (naked field), `oksa.alpha.api/select`, `oksa.alpha.api/fragment-spread`, or `oksa.alpha.api/inline-fragment`")
     (oksa.parse/-selection-set selections*)))
 
 (defn field

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -962,6 +962,7 @@
                                              (let [[selection-type value] node]
                                                (cond-> (into []
                                                              [(case selection-type
+                                                                :oksa.parse/Field (oksa.util/transform-malli-ast -transform-map node)
                                                                 :oksa.parse/NakedField (oksa.util/transform-malli-ast -transform-map [:oksa.parse/Field [value {}]])
                                                                 :oksa.parse/WrappedField (oksa.util/transform-malli-ast -transform-map value)
                                                                 :oksa.parse/FragmentSpread (oksa.util/transform-malli-ast -transform-map value)

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -99,14 +99,17 @@
                                 [:? [:schema [:ref ::TypeOpts]]]
                                 [:schema [:ref ::Type]]]
    ::SelectionSet [:orn
-                   [::SelectionSet [:+ [:catn
-                                        [::node [:schema [:ref ::Selection]]]
-                                        [::children [:? [:schema [:ref ::SelectionSet]]]]]]]]
+                   [::SelectionSet [:+ [:alt
+                                        [:catn
+                                         [::node [:schema [:ref ::Selection]]]
+                                         [::children [:? [:schema [:ref ::SelectionSet]]]]]
+                                        [:catn
+                                         [::node [:schema [:ref ::FieldSelection]]]]]]]]
+   ::FieldSelection [:orn [::WrappedField [:schema [:ref ::Field]]]]
    ::Selection [:orn
                 [::FragmentSpread [:schema [:ref ::FragmentSpread]]]
                 [::InlineFragment [:schema [:ref ::InlineFragment]]]
-                [::NakedField [:schema [:ref ::NakedField]]]
-                [::WrappedField [:schema [:ref ::Field]]]]
+                [::NakedField [:schema [:ref ::NakedField]]]]
    ::Field [:orn [::Field [:cat
                            [:schema [:ref ::FieldName]]
                            [:map

--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -104,8 +104,12 @@
                                          [::node [:schema [:ref ::Selection]]]
                                          [::children [:? [:schema [:ref ::SelectionSet]]]]]
                                         [:catn
-                                         [::node [:schema [:ref ::FieldSelection]]]]]]]]
-   ::FieldSelection [:orn [::WrappedField [:schema [:ref ::Field]]]]
+                                         [::node [:schema [:ref ::WrappedField]]]]
+                                        ;; Special case where subsequent selection set is allowed
+                                        [:catn
+                                         [::node [:schema [:ref ::BareField]]]
+                                         [::children [:? [:schema [:ref ::SelectionSet]]]]]]]]]
+   ::WrappedField [:orn [::WrappedField [:schema [:ref ::Field]]]]
    ::Selection [:orn
                 [::FragmentSpread [:schema [:ref ::FragmentSpread]]]
                 [::InlineFragment [:schema [:ref ::InlineFragment]]]
@@ -119,6 +123,14 @@
                             [:directives {:optional true}
                              [:ref ::Directives]]]
                            [:? [:schema [:ref ::SelectionSet]]]]]]
+   ::BareField [:orn [::Field [:cat
+                           [:schema [:ref ::FieldName]]
+                           [:map
+                            [:alias {:optional true} [:ref ::Alias]]
+                            [:arguments {:optional true}
+                             [:ref ::Arguments]]
+                            [:directives {:optional true}
+                             [:ref ::Directives]]]]]]
    ::NakedField [:schema [:ref ::FieldName]]
    ::FieldName [:and
                 [:schema [:ref ::Name]]

--- a/test/oksa/alpha/api_test.cljc
+++ b/test/oksa/alpha/api_test.cljc
@@ -101,7 +101,10 @@
     (t/is (= "{bar{qux{baz}}}"
              (unparse-and-validate (api/select :bar
                                      (api/select :qux
-                                      (api/select :baz))))
+                                       (api/select :baz))))
+             (unparse-and-validate (api/select (api/field :bar)
+                                     (api/select (api/field :qux)
+                                       (api/select (api/field :baz)))))
              (unparse-and-validate (api/select
                                      (api/field :bar
                                        (api/select
@@ -481,12 +484,20 @@
              (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directive :fooDirective {:fooArg 123}))
                                                           :Bar))
                                      (api/select :fooField))))))
-  (t/testing "sequential selection sets should throw an exception"
-    (t/is (thrown? #?(:clj Exception :cljs js/Error)
-                   (oksa/gql
-                     (api/select (api/field :foo
-                                   (api/select :qux :baz))
-                       (api/select :basho)))))))
+  (t/testing "sequentiality"
+    (t/is (= "{foo{bar}}"
+             (unparse-and-validate
+               (api/select
+                 (api/field :foo)
+                 (api/select :bar))))
+          "field w/o selection-set + sequential selection-set parses correctly")
+    (t/testing "sequential selection sets should throw an exception"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error)
+                     (unparse-and-validate
+                       (api/select
+                         (api/field :foo
+                           (api/select :qux :baz))
+                         (api/select :basho))))))))
 
 (t/deftest transformers-test
   (t/testing "names are transformed when transformer fn is provided"

--- a/test/oksa/alpha/api_test.cljc
+++ b/test/oksa/alpha/api_test.cljc
@@ -2,6 +2,7 @@
   (:require [camel-snake-kebab.core :as csk]
             [#?(:clj clojure.test
                 :cljs cljs.test) :as t]
+            [oksa.core :as oksa]
             [oksa.alpha.api :as api])
   #?(:clj (:import [graphql.parser Parser])))
 
@@ -101,9 +102,6 @@
              (unparse-and-validate (api/select :bar
                                      (api/select :qux
                                       (api/select :baz))))
-             (unparse-and-validate (api/select (api/field :bar)
-                                     (api/select (api/field :qux)
-                                       (api/select (api/field :baz)))))
              (unparse-and-validate (api/select
                                      (api/field :bar
                                        (api/select
@@ -482,7 +480,13 @@
     (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
              (unparse-and-validate (api/query (api/opts (api/variable :foo (api/opts (api/directive :fooDirective {:fooArg 123}))
                                                           :Bar))
-                                     (api/select :fooField)))))))
+                                     (api/select :fooField))))))
+  (t/testing "sequential selection sets should throw an exception"
+    (t/is (thrown? #?(:clj Exception :cljs js/Error)
+                   (oksa/gql
+                     (api/select (api/field :foo
+                                   (api/select :qux :baz))
+                       (api/select :basho)))))))
 
 (t/deftest transformers-test
   (t/testing "names are transformed when transformer fn is provided"

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -40,17 +40,23 @@
       (t/is (= "{subscription{subscription{baz}}}" (unparse-and-validate [:subscription [:subscription [:baz]]])))))
   (t/testing "selection set"
     (t/is (= "{foo}"
-             (unparse-and-validate [:foo])))
+             (unparse-and-validate [:foo])
+             (unparse-and-validate [[:foo {}]])))
     (t/is (= "{foo bar}"
-             (unparse-and-validate [:foo :bar])))
+             (unparse-and-validate [:foo :bar])
+             (unparse-and-validate [[:foo {}] [:bar {}]])))
     (t/is (= "{bar{qux{baz}}}"
-             (unparse-and-validate [:bar [:qux [:baz]]])))
+             (unparse-and-validate [:bar [:qux [:baz]]])
+             (unparse-and-validate [[:bar {}] [[:qux {}] [[:baz {}]]]])))
     (t/is (= "{foo bar{qux{baz}}}"
-             (unparse-and-validate [:foo :bar [:qux [:baz]]])))
+             (unparse-and-validate [:foo :bar [:qux [:baz]]])
+             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {} [[:baz {}]]]]])))
     (t/is (= "{foo bar{qux baz}}"
-             (unparse-and-validate [:foo :bar [:qux :baz]])))
+             (unparse-and-validate [:foo :bar [:qux :baz]])
+             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {}] [:baz {}]]])))
     (t/is (= "{foo{bar{baz qux} frob}}"
-             (unparse-and-validate [:foo [:bar [:baz :qux] :frob]])))
+             (unparse-and-validate [:foo [:bar [:baz :qux] :frob]])
+             (unparse-and-validate [[:foo {}] [:bar [:baz :qux] :frob]])))
     (t/testing "support strings as field names"
       (t/is (= "{foo}"
                (unparse-and-validate ["foo"])
@@ -299,7 +305,13 @@
                                     [:fooField]]))))
   (t/testing "sequential selection sets should throw an exception"
     (t/is (thrown? #?(:clj Exception :cljs js/Error)
-                   (oksa/gql [[:foo {} [:qux :baz]] [:basho]])))))
+                   (oksa/gql [[:foo {} [:qux :baz]] [:basho]]))))
+  (t/testing "sequentiality"
+    (t/is (= "{foo{bar}}"
+             (unparse-and-validate [[:foo {}] [:bar]])) "field w/o selection-set + sequential selection-set parses correctly")
+    (t/testing "sequential selection sets should throw an exception"
+      (t/is (thrown? #?(:clj Exception :cljs js/Error)
+                     (unparse-and-validate [[:foo {} [:qux :baz]] [:basho]]))))))
 
 (t/deftest transformers-test
   (t/testing "names are transformed when transformer fn is provided"

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -2,7 +2,7 @@
   (:require [camel-snake-kebab.core :as csk]
             [#?(:clj  clojure.test
                 :cljs cljs.test) :as t]
-            [oksa.core]
+            [oksa.core :as oksa]
             [oksa.test-util :refer [unparse-and-validate]]
             [oksa.alpha.api :as api])
   #?(:clj (:import [graphql.parser Parser])))
@@ -296,7 +296,10 @@
                                     [:fooField]])))
     (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
              (unparse-and-validate [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
-                                    [:fooField]])))))
+                                    [:fooField]]))))
+  (t/testing "sequential selection sets should throw an exception"
+    (t/is (thrown? #?(:clj Exception :cljs js/Error)
+                   (oksa/gql [[:foo {} [:qux :baz]] [:basho]])))))
 
 (t/deftest transformers-test
   (t/testing "names are transformed when transformer fn is provided"

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -47,16 +47,20 @@
              (unparse-and-validate [[:foo {}] [:bar {}]])))
     (t/is (= "{bar{qux{baz}}}"
              (unparse-and-validate [:bar [:qux [:baz]]])
-             (unparse-and-validate [[:bar {}] [[:qux {}] [[:baz {}]]]])))
+             (unparse-and-validate [[:bar {}] [[:qux {}] [[:baz {}]]]])
+             (unparse-and-validate [[:bar {} [[:qux {} [[:baz {}]]]]]])))
     (t/is (= "{foo bar{qux{baz}}}"
              (unparse-and-validate [:foo :bar [:qux [:baz]]])
-             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {} [[:baz {}]]]]])))
+             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {} [[:baz {}]]]]])
+             (unparse-and-validate [[:foo {}] [:bar {} [[:qux {} [[:baz {}]]]]]])))
     (t/is (= "{foo bar{qux baz}}"
              (unparse-and-validate [:foo :bar [:qux :baz]])
-             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {}] [:baz {}]]])))
+             (unparse-and-validate [[:foo {}] [:bar {}] [[:qux {}] [:baz {}]]])
+             (unparse-and-validate [[:foo {}] [:bar {} [[:qux {}] [:baz {}]]]])))
     (t/is (= "{foo{bar{baz qux} frob}}"
              (unparse-and-validate [:foo [:bar [:baz :qux] :frob]])
-             (unparse-and-validate [[:foo {}] [:bar [:baz :qux] :frob]])))
+             (unparse-and-validate [[:foo {}] [:bar [:baz :qux] :frob]])
+             (unparse-and-validate [[:foo {} [:bar [:baz :qux] :frob]]])))
     (t/testing "support strings as field names"
       (t/is (= "{foo}"
                (unparse-and-validate ["foo"])

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -2,7 +2,7 @@
   (:require [camel-snake-kebab.core :as csk]
             [#?(:clj  clojure.test
                 :cljs cljs.test) :as t]
-            [oksa.core :as oksa]
+            [oksa.core]
             [oksa.test-util :refer [unparse-and-validate]]
             [oksa.alpha.api :as api])
   #?(:clj (:import [graphql.parser Parser])))
@@ -305,7 +305,7 @@
                                     [:fooField]]))))
   (t/testing "sequential selection sets should throw an exception"
     (t/is (thrown? #?(:clj Exception :cljs js/Error)
-                   (oksa/gql [[:foo {} [:qux :baz]] [:basho]]))))
+                   (unparse-and-validate [[:foo {} [:qux :baz]] [:basho]]))))
   (t/testing "sequentiality"
     (t/is (= "{foo{bar}}"
              (unparse-and-validate [[:foo {}] [:bar]])) "field w/o selection-set + sequential selection-set parses correctly")

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -307,9 +307,6 @@
     (t/is (= "query ($foo:Bar @fooDirective(fooArg:123)){fooField}"
              (unparse-and-validate [:oksa/query {:variables [:foo {:directives [[:fooDirective {:arguments {:fooArg 123}}]]} :Bar]}
                                     [:fooField]]))))
-  (t/testing "sequential selection sets should throw an exception"
-    (t/is (thrown? #?(:clj Exception :cljs js/Error)
-                   (unparse-and-validate [[:foo {} [:qux :baz]] [:basho]]))))
   (t/testing "sequentiality"
     (t/is (= "{foo{bar}}"
              (unparse-and-validate [[:foo {}] [:bar]])) "field w/o selection-set + sequential selection-set parses correctly")


### PR DESCRIPTION
It was possible to write:

```clojure
(oksa.core/gql [[:foo {} [:qux :baz]] [:basho]])
; or
(oksa.core/gql
  (oksa.alpha.api/select (oksa.alpha.api/field :foo
                                (oksa.alpha.api/select :qux :baz))
                         (oksa.alpha.api/select :basho)))
```

resulting in incorrect GraphQL:

```graphql
{foo{qux baz}{basho}}
```

This PR fixes the parser to consider sequential selection sets as invalid. ~We also remove an API test case that was invalid to begin with.~ (Edit: removed, see explanation.)