### PR TITLE
Restrict fragment-spread map to be required

### DIFF
--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -137,11 +137,11 @@
                 [:fn #(not (@reserved-keywords %))]]
    ::FragmentSpread [:cat
                      [:enum :oksa/fragment-spread :...]
-                     [:? [:map
-                          [:name {:optional false}
-                           [:ref ::FragmentName]]
-                          [:directives {:optional true}
-                           [:ref ::Directives]]]]]
+                     [:map
+                      [:name {:optional false}
+                       [:ref ::FragmentName]]
+                      [:directives {:optional true}
+                       [:ref ::Directives]]]]
    ::InlineFragment [:cat
                      [:enum :oksa/inline-fragment :...]
                      [:? [:map

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -133,7 +133,8 @@
   (t/testing "fragment spread"
     (t/is (= "{foo ...bar}"
              (unparse-and-validate [:foo [:... {:name :bar}]])
-             (unparse-and-validate [:foo [:oksa/fragment-spread {:name :bar}]]))))
+             (unparse-and-validate [:foo [:oksa/fragment-spread {:name :bar}]])))
+    (t/is (thrown? #?(:clj Exception :cljs js/Error) (unparse-and-validate [[:oksa/fragment-spread]]))))
   (t/testing "inline fragment"
     (t/is (= "{foo ...{bar}}"
              (unparse-and-validate [:foo [:... [:bar]]])


### PR DESCRIPTION
This was discovered from the [first series](https://github.com/metosin/oksa/actions/runs/9390403675/job/25860325296) of generative test runs:

```clojure
(oksa.core/gql [[:oksa/fragment-spread]])
; => Execution error (AssertionError) at oksa.parse/fn$fragment-spread (parse.cljc:949).
; => Assert failed: missing name
; => (some? (:name options))
```

Changes map for fragment spread to be non-optional. This is because `:name` is a required field for fragment spread.

The change is breaking in a spec sense, practically though we are just trading one exception into an earlier exception (now terminating during malli parse).