### PR TITLE
Restrict values inside ListValue and ObjectValue

### DIFF
--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -180,8 +180,8 @@
                     (or (re-matches re-variable-reference s)
                         (re-matches re-enum-value s))))]]
               :keyword)
-            coll?
-            :map]
+            [:sequential [:ref ::Value]]
+            [:map-of [:ref ::Name] [:ref ::Value]]]
    ::Arguments [:map-of [:ref ::Name] [:ref ::Value]]
    ::Directives [:orn [::Directives [:+ [:orn
                                          [::DirectiveName [:schema [:ref ::DirectiveName]]]

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -88,7 +88,10 @@
         (t/is (= "{fooField(foo:\"\\\\\")}"
                  (unparse-and-validate [[:fooField {:arguments {:foo "\\"}}]])))
         (t/is (= "{fooField(foo:\"foo\\b\\f\\r\\n\\tbar\")}"
-                 (unparse-and-validate [[:fooField {:arguments {:foo (str "foo\b\f\r\n\tbar")}}]]))))))
+                 (unparse-and-validate [[:fooField {:arguments {:foo (str "foo\b\f\r\n\tbar")}}]]))))
+      (t/is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"invalid form"
+                              (unparse-and-validate [[:foo {:arguments {:foo #uuid"5bc915e9-1a9a-4780-8cf9-16aae80ec3fc"}}
+                                                      [:bar]]])))))
   (t/testing "document"
     (t/is (= "{foo}"
              (unparse-and-validate [:<> [:foo]])


### PR DESCRIPTION
From the [first series](https://github.com/metosin/oksa/actions/runs/9390403675/job/25860325296) of generative test runs, we was discovered that values inside [list values](https://spec.graphql.org/October2021/#ListValue) and [object values](https://spec.graphql.org/October2021/#ObjectValue) could be anything. This PR restricts those values according to the [spec](https://spec.graphql.org/October2021/#Value).