### PR TITLE
Add missing :min to selection set refs

### DIFF
--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -51,7 +51,7 @@
                           [:on [:ref ::Name]]
                           [:directives {:optional true}
                            [:schema [:ref ::Directives]]]]
-                         [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+                         [:repeat {:min 1 :max 1} [:schema [:ref ::SelectionSet]]]]
    ::OperationDefinition [:or
                           [:cat
                            [:enum :oksa/query :oksa/mutation :oksa/subscription]
@@ -61,7 +61,7 @@
                                  [:schema [:ref ::VariableDefinitions]]]
                                 [:directives {:optional true}
                                  [:schema [:ref ::Directives]]]]]
-                           [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+                           [:repeat {:min 1 :max 1} [:schema [:ref ::SelectionSet]]]]
                           [:schema [:ref ::SelectionSet]]]
    ::VariableDefinitions [:orn [::VariableDefinitions
                                 [:+ [:cat
@@ -149,7 +149,7 @@
                            [:ref ::Directives]]
                           [:on {:optional true}
                            [:ref ::Name]]]]
-                     [:repeat {:max 1} [:schema [:ref ::SelectionSet]]]]
+                     [:repeat {:min 1 :max 1} [:schema [:ref ::SelectionSet]]]]
    ::Alias [:schema [:ref ::Name]]
    ::Name (if (:oksa/strict opts)
             [:and [:or :keyword :string]


### PR DESCRIPTION
This is the last fix to the [first series](https://github.com/metosin/oksa/actions/runs/9390403675/job/25860325296) of generative test runs. This one addresses omitted selection sets from fragment definitions, operation definitions, and inline fragments. The problem that we ran into was the following:

> No implementation of method: :-unparse of protocol: #'oksa.alpha.protocol/Serializable found for class: nil

And the fix is to require the selection set to always be present since this is what the spec also says.