### PR TITLE
Add support for persistent hash map formatting

### DIFF
--- a/src/oksa/unparse.cljc
+++ b/src/oksa/unparse.cljc
@@ -1,7 +1,7 @@
 (ns oksa.unparse
   (:require [clojure.string :as str]
             [oksa.alpha.protocol :as protocol])
-  #?(:clj (:import (clojure.lang Keyword PersistentVector PersistentArrayMap))))
+  #?(:clj (:import (clojure.lang Keyword PersistentHashMap PersistentVector PersistentArrayMap))))
 
 (defmulti format-value type)
 
@@ -71,13 +71,20 @@
                            :cljs cljs.core/PersistentVector)
   [x]
   (str "[" (clojure.string/join " " (mapv format-value x)) "]"))
-(defmethod format-value #?(:clj PersistentArrayMap
-                           :cljs cljs.core/PersistentArrayMap)
+(defn format-map
   [x]
   (str "{"
        (str/join ", " (map (fn [[object-field-name object-field-value]]
                              (str (name object-field-name) ":" (format-value object-field-value))) x))
        "}"))
+(defmethod format-value #?(:clj PersistentArrayMap
+                           :cljs cljs.core/PersistentArrayMap)
+  [x]
+  (format-map x))
+(defmethod format-value #?(:clj PersistentHashMap
+                           :cljs cljs.core/PersistentHashMap)
+  [x]
+  (format-map x))
 
 (defn -format-argument
   [name value]

--- a/test/oksa/alpha/api_test.cljc
+++ b/test/oksa/alpha/api_test.cljc
@@ -174,6 +174,20 @@
                                                     (api/argument :g {:frob {:foo 1
                                                                              :bar 2}})
                                                     (api/argument :h :$fooVar)))))))
+      (t/is (= "{foo(args:{e:5, g:7, c:3, h:8, b:2, d:4, f:6, i:9, a:1})}"
+               (unparse-and-validate (api/select (api/field :foo
+                                                   (api/opts
+                                                     (api/arguments :args {:a 1
+                                                                           :b 2
+                                                                           :c 3
+                                                                           :d 4
+                                                                           :e 5
+                                                                           :f 6
+                                                                           :g 7
+                                                                           :h 8
+                                                                           :i 9}))))))
+            "hash maps")
+
       #?(:clj (t/is (= "{foo(a:0.3333333333333333)}"
                        (unparse-and-validate (api/select (api/field :foo (api/opts (api/argument :a 1/3)))))
                        (unparse-and-validate (api/select (api/field :foo (api/opts (api/arguments :a 1/3))))))))

--- a/test/oksa/core_test.cljc
+++ b/test/oksa/core_test.cljc
@@ -80,6 +80,17 @@
                                                          :g {:frob {:foo 1
                                                                     :bar 2}}
                                                          :h :$fooVar}}]])))
+      (t/is (= "{foo(args:{e:5, g:7, c:3, h:8, b:2, d:4, f:6, i:9, a:1})}"
+               (unparse-and-validate [[:foo {:arguments {:args {:a 1
+                                                                :b 2
+                                                                :c 3
+                                                                :d 4
+                                                                :e 5
+                                                                :f 6
+                                                                :g 7
+                                                                :h 8
+                                                                :i 9}}}]]))
+            "hash maps")
       #?(:clj (t/is (= "{foo(a:0.3333333333333333)}"
                        (unparse-and-validate [[:foo {:arguments {:a 1/3}}]]))))
       (t/testing "escaping special characters"


### PR DESCRIPTION
Fixes a [finding](https://github.com/metosin/oksa/actions/runs/9420320114/job/25952091858) from the latest generative test run:

> No method in multimethod 'format-value' for dispatch value: class clojure.lang.PersistentHashMap

The offending (reduced) payload being:

```clojure
(gql '(("Px6yr3Z6"
         {:arguments {"I58LwWPr5" {"BnX8" 2,
                                   :F {},
                                   "mfvh" true,
                                   "Gx7uc" [],
                                   :l nil,
                                   :b {},
                                   "v9SN" nil,
                                   "Qpe41O8j" "304P44x3X",
                                   :gF5 :v,
                                   "m" {}}}})))
```

The fix was to implement `format-value` for hash maps using the same implementation as for array maps.