### PR TITLE
Add `test-doc-blocks` to run tests against examples in README.md

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,10 @@
                                     org.clojure/clojurescript {:mvn/version "1.11.57"}
                                     camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}}
                        :main-opts ["-m" "cljs-test-runner.main"]}
+           :gen-doc-tests {:replace-deps {org.clojure/clojure {:mvn/version "1.10.3"}
+                                          com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
+                           :exec-fn lread.test-doc-blocks/gen-tests
+                           :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}
            :clojure-10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :clojure-11 {}
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.0" :git/sha "3a2c484"}}

--- a/tests.edn
+++ b/tests.edn
@@ -1,3 +1,5 @@
 #kaocha/v1
 {:tests [{:id   :unit
-          :type :kaocha.type/clojure.test}]}
+          :type :kaocha.type/clojure.test}
+         {:id         :generated
+          :test-paths ["target/test-doc-blocks/test"]}]}


### PR DESCRIPTION
Test set can be generated with
  `clojure -X:gen-doc-tests`

Generated test set can be run with
  `clojure -M:test -m kaocha.runner generated`