### PR TITLE
Add mode check to `oksa.parse/parse`

### DIFF
--- a/src/oksa/parse.cljc
+++ b/src/oksa/parse.cljc
@@ -276,21 +276,22 @@
 (defn- parse
   [x]
   (let [parsed (-graphql-dsl-parser x)]
-    (if (not= :malli.core/invalid parsed)
-      parsed
-      (let [explained (m/explain (-graphql-dsl-lang ::Document) x)
-            errors    (:errors explained)]
-        (throw (ex-info (str "oksa: invalid GQL form\n"
-                             "  form: " (pr-str x) "\n"
-                             "  errors:\n"
-                             (apply str (map (fn [e]
-                                              (str "    - path: " (:path e)
-                                                   " in: " (:in e)
-                                                   " value: " (pr-str (:value e))
-                                                   " schema: " (:schema e) "\n"))
-                                             (take 5 errors))))
-                        {:form   x
-                         :errors errors}))))))
+    (cond
+      (not= :malli.core/invalid parsed) parsed
+      (= mode "debug") (let [explained (m/explain (-graphql-dsl-lang ::Document) x)
+                             errors (:errors explained)]
+                         (throw (ex-info (str "oksa: invalid GQL form\n"
+                                              "  form: " (pr-str x) "\n"
+                                              "  errors (sampled):\n"
+                                              (apply str (map (fn [e]
+                                                                (str "    - path: " (:path e)
+                                                                     " in: " (:in e)
+                                                                     " value: " (pr-str (:value e))
+                                                                     " schema: " (:schema e) "\n"))
+                                                              (take 5 errors))))
+                                         {:form x
+                                          :errors errors})))
+      :else (throw (ex-info "invalid form" {})))))
 
 (defn -operation-definition-form
   [operation-type opts selection-set]


### PR DESCRIPTION
A continuation of https://github.com/metosin/oksa/pull/28

Previous PR added useful debug information to exceptions in `oksa.parse/parse`. This PR adds a check to enable said debug information only when system property `oksa.api/mode` is given using `debug` value. This is similar to how it's already done in `oksa.parse/-parse-or-throw`.